### PR TITLE
Use templates

### DIFF
--- a/capstone/src/main/webapp/about-us.html
+++ b/capstone/src/main/webapp/about-us.html
@@ -33,7 +33,14 @@
           <input type="text" name="announcement-text" placeholder="Add announcement...">
           <input type="submit" value="Post">
       </div>
-      <div id="announcements-display" class="full-screen-panel"></div>
+      <div class="full-screen-panel">
+        <h1>Announcements</h1>
+        <ul id="announcements-display">
+          <template id="announcement-element">
+            <li></li>
+          </template>
+        </ul>
+      </div>
     </template>
     <template id="calendar">
       <p>Calendar goes here</p>

--- a/capstone/src/main/webapp/explore-loader.js
+++ b/capstone/src/main/webapp/explore-loader.js
@@ -10,21 +10,14 @@ async function getListings () {
 }
 
 function loadListings (json) {
-  const section = document.getElementById('club-listings');
-  section.innerHTML = '';
-  for (var index in json) {
-    section.innerHTML += '<div class="club-listing">' + 
-                           '<div class="club-logo-container">' + 
-                             '<img src="images/logo.png" class="club-logo" alt="Club logo">' + 
-                           '</div>' + 
-                           '<div class="club-info-container">' + 
-                             '<h2><a href="about-us.html?name=' + json[index].name + '">' + json[index].name + '</a></h2>' + 
-                             '<p>' + json[index].description + '</p>' + 
-                             '<p>' + json[index].members.length + ' members</p>' +     
-                           '</div>' + 
-                           '<div class="club-join-container">' + 
-                             '<button onclick="location.href=\'about-us.html\';">Join club</button>' + 
-                           '</div>' + 
-                         '</div>';
+  const template = document.querySelector('#club-listing');
+  for (var club of json) {
+    template.content.querySelector('#club-logo').src = 'images/logo.png';
+    template.content.querySelector('#club-name').innerHTML = club.name;
+    template.content.querySelector('#description').innerHTML = club.description;
+    template.content.querySelector('#members').innerHTML = club.members.length + " members";
+    var clone = document.importNode(template.content, true);
+    document.getElementById('club-listings').appendChild(clone);    
   }
 }
+

--- a/capstone/src/main/webapp/explore-loader.js
+++ b/capstone/src/main/webapp/explore-loader.js
@@ -16,7 +16,7 @@ function loadListings (json) {
     template.content.querySelector('#club-name').innerHTML = club.name;
     template.content.querySelector('#club-name').href = 'about-us.html?name=' + club.name;
     template.content.querySelector('#description').innerHTML = club.description;
-    template.content.querySelector('#members').innerHTML = club.members.length + " members";
+    template.content.querySelector('#members').innerHTML = club.members.length + ' members';
     var clone = document.importNode(template.content, true);
     document.getElementById('club-listings').appendChild(clone);    
   }

--- a/capstone/src/main/webapp/explore-loader.js
+++ b/capstone/src/main/webapp/explore-loader.js
@@ -14,6 +14,7 @@ function loadListings (json) {
   for (var club of json) {
     template.content.querySelector('#club-logo').src = 'images/logo.png';
     template.content.querySelector('#club-name').innerHTML = club.name;
+    template.content.querySelector('#club-name').href = 'about-us.html?name=' + club.name;
     template.content.querySelector('#description').innerHTML = club.description;
     template.content.querySelector('#members').innerHTML = club.members.length + " members";
     var clone = document.importNode(template.content, true);

--- a/capstone/src/main/webapp/index.html
+++ b/capstone/src/main/webapp/index.html
@@ -13,32 +13,19 @@
     <h1>Explore Clubs</h1>
     <div id="content">
       <div id="club-listings" class="full-screen-panel">
-        <div class="club-listing">
+        <template id="club-listing">
           <div class="club-logo-container">
-            <img src="images/image1.png" class="club-logo" alt="Club logo">
+            <img src="" id="club-logo" class="club-logo" alt="Club logo">
           </div>
           <div class="club-info-container">
-            <h2>Club 1</h2>
-            <p>We are a club</p>
-            <p>10 members</p>
+            <h2><a href="" id="club-name"></a></h2>
+            <p id="description"></p>
+            <p id="members">10 members</p>
           </div> 
           <div class="club-join-container">
             <button onclick="location.href='about-us.html';">Join club</button>
           </div>
-        </div>
-        <div class="club-listing">
-          <div class="club-logo-container">
-            <img src="images/logo.png" class="club-logo" alt="Club logo">
-          </div>
-          <div class="club-info-container">
-            <h2>Club 2</h2>
-            <p>We do cool club things</p>
-            <p>20 members</p>
-          </div> 
-          <div class="club-join-container">
-            <button onclick="location.href='about-us.html';">Join club</button>
-          </div>
-        </div>
+        </template>
       </div>
       <button id="register-club-button" onclick="location.href='club-registration.html';">Register a new club!</button>
     </div>

--- a/capstone/src/main/webapp/index.html
+++ b/capstone/src/main/webapp/index.html
@@ -20,7 +20,7 @@
           <div class="club-info-container">
             <h2><a href="" id="club-name"></a></h2>
             <p id="description"></p>
-            <p id="members">10 members</p>
+            <p id="members"></p>
           </div> 
           <div class="club-join-container">
             <button onclick="location.href='about-us.html';">Join club</button>

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -44,13 +44,13 @@ async function loadAnnouncements () {
   const query = '/announcements?name=' + params.get('name');
   const response = await fetch(query);
   const json = await response.json();
-  const announcementsSection = document.getElementById('announcements-display');
-  announcementsSection.innerHTML = '<h1>Announcements</h1>';
-  announcementsSection.innerHTML += '<ul>';
-  for (var index in json) {
-      announcementsSection.innerHTML += '<li>'+json[index]+'</li>';
+  console.log(json);
+  const template = document.querySelector('#announcement-element');
+  for (var announcement of json) {
+    template.content.querySelector('li').innerHTML = announcement;
+    var clone = document.importNode(template.content, true);
+    document.getElementById('announcements-display').appendChild(clone);
   }
-  announcementsSection.innerHTML += '</ul>';
 }
 
 /** Displays club info tab, depending on which tab user selected. */

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -44,7 +44,6 @@ async function loadAnnouncements () {
   const query = '/announcements?name=' + params.get('name');
   const response = await fetch(query);
   const json = await response.json();
-  console.log(json);
   const template = document.querySelector('#announcement-element');
   for (var announcement of json) {
     template.content.querySelector('li').innerHTML = announcement;


### PR DESCRIPTION
This PR switches the explore page and the announcements page to use templates. This way, the HTML code is cleanly in the HTML files, instead of (kind of hackily) in the JS. The Java servlet still behaves the same way, and the JavaScript simply takes the same JSON data and loads the template, then makes a clone and appends it in the proper place. 