### PR TITLE
Transition from using hardcoded club data to Datastore

### DIFF
--- a/capstone/WEB-INF/appengine-generated/datastore-indexes-auto.xml
+++ b/capstone/WEB-INF/appengine-generated/datastore-indexes-auto.xml
@@ -1,4 +1,4 @@
-<!-- Indices written at Fri, 31 Jul 2020 17:47:23 UTC -->
+<!-- Indices written at Fri, 31 Jul 2020 19:59:13 UTC -->
 
 <datastore-indexes/>
 

--- a/capstone/WEB-INF/appengine-generated/datastore-indexes-auto.xml
+++ b/capstone/WEB-INF/appengine-generated/datastore-indexes-auto.xml
@@ -1,4 +1,0 @@
-<!-- Indices written at Mon, 3 Aug 2020 19:48:31 UTC -->
-
-<datastore-indexes/>
-

--- a/capstone/WEB-INF/appengine-generated/datastore-indexes-auto.xml
+++ b/capstone/WEB-INF/appengine-generated/datastore-indexes-auto.xml
@@ -1,4 +1,4 @@
-<!-- Indices written at Fri, 31 Jul 2020 19:59:13 UTC -->
+<!-- Indices written at Mon, 3 Aug 2020 19:48:31 UTC -->
 
 <datastore-indexes/>
 

--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -4,7 +4,6 @@ package com.google.sps.servlets;
 class Constants {
   private Constants() {}
 
-  static final String CLUB_NAME_PROP = "name";
   static final String PROPERTY_NAME = "name";
   static final String PROPERTY_EMAIL = "email";
   static final String PROPERTY_GRADYEAR = "gradYear";
@@ -17,5 +16,4 @@ class Constants {
   static final String OFFICER_PROP = "officers";
   static final String ANNOUNCE_PROP = "announcements";
   static final int LOAD_LIMIT = 10;
-
 }

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
@@ -37,7 +37,7 @@ public class AnnouncementsServlet extends HttpServlet {
     // Get announcements object based on the logged in email
     UserService userService = UserServiceFactory.getUserService();
     String userEmail = userService.getCurrentUser().getEmail();
-    String clubName = request.getParameter(Constants.CLUB_NAME_PROP);
+    String clubName = request.getParameter(Constants.PROPERTY_NAME);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Query query =
@@ -68,7 +68,7 @@ public class AnnouncementsServlet extends HttpServlet {
 
     UserService userService = UserServiceFactory.getUserService();
     String userEmail = userService.getCurrentUser().getEmail();
-    String clubName = request.getParameter(Constants.CLUB_NAME_PROP);
+    String clubName = request.getParameter(Constants.PROPERTY_NAME);
     String announcementContent = request.getParameter(ANNOUNCEMENTS_CONTENT_PROP);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -34,7 +34,7 @@ public class ClubServlet extends HttpServlet {
 
     Entity clubEntity = retrieveClub(request, datastore).asSingleEntity();
 
-    String name = clubEntity.getProperty(Constants.CLUB_NAME_PROP).toString();
+    String name = clubEntity.getProperty(Constants.PROPERTY_NAME).toString();
     ImmutableList<String> members =
         ImmutableList.copyOf((ArrayList<String>) clubEntity.getProperty(Constants.MEMBER_PROP));
     ImmutableList<String> officers =
@@ -72,13 +72,13 @@ public class ClubServlet extends HttpServlet {
     boolean isValid = Iterables.isEmpty(prepared.asIterable());
 
     if (isValid) {
-      String clubName = request.getParameter(Constants.CLUB_NAME_PROP);
+      String clubName = request.getParameter(Constants.PROPERTY_NAME);
       String description = request.getParameter(Constants.DESCRIP_PROP);
       String website = request.getParameter(Constants.WEBSITE_PROP);
       BlobKey key = getBlobKey(request, Constants.LOGO_PROP, blobstore);
 
       Entity clubEntity = new Entity("Club", clubName);
-      clubEntity.setProperty(Constants.CLUB_NAME_PROP, clubName);
+      clubEntity.setProperty(Constants.PROPERTY_NAME, clubName);
       clubEntity.setProperty(Constants.DESCRIP_PROP, description);
       clubEntity.setProperty(Constants.WEBSITE_PROP, website);
       clubEntity.setProperty(Constants.MEMBER_PROP, ImmutableList.of(founderEmail));
@@ -112,9 +112,9 @@ public class ClubServlet extends HttpServlet {
         new Query("Club")
             .setFilter(
                 new FilterPredicate(
-                    Constants.CLUB_NAME_PROP,
+                    Constants.PROPERTY_NAME,
                     FilterOperator.EQUAL,
-                    request.getParameter(Constants.CLUB_NAME_PROP)));
+                    request.getParameter(Constants.PROPERTY_NAME)));
     PreparedQuery prepared = datastore.prepare(query);
     return prepared;
   }

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -33,22 +33,24 @@ public class ClubServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Entity clubEntity = retrieveClub(request, datastore).asSingleEntity();
-
-    String name = clubEntity.getProperty(Constants.PROPERTY_NAME).toString();
-    ImmutableList<String> members =
-        ImmutableList.copyOf((ArrayList<String>) clubEntity.getProperty(Constants.MEMBER_PROP));
-    ImmutableList<String> officers =
-        ImmutableList.copyOf((ArrayList<String>) clubEntity.getProperty(Constants.OFFICER_PROP));
-    String description = clubEntity.getProperty(Constants.DESCRIP_PROP).toString();
-    String website = clubEntity.getProperty(Constants.WEBSITE_PROP).toString();
-    ImmutableList<String> announcements =
-        ImmutableList.copyOf((ArrayList<String>) clubEntity.getProperty(Constants.ANNOUNCE_PROP));
-    Club club = new Club(name, members, officers, description, website, announcements);
-
-    Gson gson = new Gson();
-    String json = gson.toJson(club);
-    response.setContentType("text/html;");
-    response.getWriter().println(json);
+    if (clubEntity != null) {
+      String name = clubEntity.getProperty(Constants.PROPERTY_NAME).toString();
+      ImmutableList<String> members =
+          ImmutableList.copyOf((ArrayList<String>) clubEntity.getProperty(Constants.MEMBER_PROP));
+      ImmutableList<String> officers =
+          ImmutableList.copyOf((ArrayList<String>) clubEntity.getProperty(Constants.OFFICER_PROP));
+      String description = clubEntity.getProperty(Constants.DESCRIP_PROP).toString();
+      String website = clubEntity.getProperty(Constants.WEBSITE_PROP).toString();
+      ImmutableList<String> announcements =
+          ImmutableList.copyOf((ArrayList<String>) clubEntity.getProperty(Constants.ANNOUNCE_PROP));
+      Club club = new Club(name, members, officers, description, website, announcements);
+      Gson gson = new Gson();
+      String json = gson.toJson(club);
+      response.setContentType("text/html;");
+      response.getWriter().println(json);
+    } else {
+      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
   }
 
   @Override

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -21,9 +21,14 @@ const topNavBar =
 document.write(topNavBar);
 
 /** Load 'About Us' Club info tab. Default page displayed when user first enters club page. */
-function getClubInfo() {
+async function getClubInfo() {
   var params = new URLSearchParams(window.location.search);
-  fetch('/clubs?name=' + params.get('name')).then(response => response.json()).then((clubInfo) => {
+  const response = await fetch('/clubs?name=' + params.get('name'));
+  if (response.status == 400) {
+    alert("Invalid club! Returning to Explore.");
+    window.location.replace("index.html");
+  } else {
+    const clubInfo = await response.json();
     document.getElementById('club-name').innerHTML = clubInfo['name'];
     document.getElementById('description').innerHTML = clubInfo['description'];
     
@@ -38,7 +43,7 @@ function getClubInfo() {
 
     document.getElementById('members').innerHTML = '# of Members: ' + clubInfo['members'].length;
     document.getElementById('website').innerHTML = 'Website: ' + clubInfo['website'];
-  });
+  }
 }
 
 /** Accesses and displays club announcement data from servlet. */

--- a/capstone/src/test/java/com/google/sps/clubs/ClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/clubs/ClubServletTest.java
@@ -1,5 +1,6 @@
 package com.google.sps.servlets;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.mockito.Mockito.when;
 
 import com.google.appengine.api.blobstore.BlobKey;
@@ -16,7 +17,13 @@ import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.List;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -36,13 +43,10 @@ public class ClubServletTest {
 
   private final String SAMPLE_CLUB_NAME = "Club 1";
   private final String SAMPLE_CLUB_DESC_1 = "Test club description";
-  private final String SAMPLE_CLUB_DESC_2 = "Another club description";
   private final String SAMPLE_CLUB_WEB = "www.test-club.com";
   private final BlobKey SAMPLE_BLOB = new BlobKey("test-blobkey");
   private final String TEST_EMAIL = "test-email@gmail.com";
   private final ImmutableList<String> STUDENT_LIST = ImmutableList.of(TEST_EMAIL);
-  private final String VALID_URL = "/registration-msg.html?is-valid=true";
-  private final String INVALID_URL = "/registration-msg.html?is-valid=false";
 
   @Mock private HttpServletRequest request;
   @Mock private HttpServletResponse response;
@@ -65,6 +69,15 @@ public class ClubServletTest {
     this.blobstoreServlet = new BlobstoreServlet();
     datastore = DatastoreServiceFactory.getDatastoreService();
     blobstore = Mockito.mock(BlobstoreService.class);
+
+    helper.setEnvEmail(TEST_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
+    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn(SAMPLE_CLUB_NAME);
+    when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn(SAMPLE_CLUB_DESC_1);
+    when(request.getParameter(Constants.WEBSITE_PROP)).thenReturn(SAMPLE_CLUB_WEB);
+
+    ImmutableList<BlobKey> keys = ImmutableList.of(SAMPLE_BLOB);
+    ImmutableMap<String, List<BlobKey>> blobMap = ImmutableMap.of(Constants.LOGO_PROP, keys);
+    when(blobstore.getUploads(request)).thenReturn(blobMap);
   }
 
   @After
@@ -74,15 +87,6 @@ public class ClubServletTest {
 
   @Test
   public void doPost_registerNewValidClub() throws ServletException, IOException {
-    helper.setEnvEmail(TEST_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
-    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn(SAMPLE_CLUB_NAME);
-    when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn(SAMPLE_CLUB_DESC_1);
-    when(request.getParameter(Constants.WEBSITE_PROP)).thenReturn(SAMPLE_CLUB_WEB);
-
-    ImmutableList<BlobKey> keys = ImmutableList.of(SAMPLE_BLOB);
-    ImmutableMap<String, List<BlobKey>> blobMap = ImmutableMap.of(Constants.LOGO_PROP, keys);
-    when(blobstore.getUploads(request)).thenReturn(blobMap);
-
     clubServlet.doPostHelper(request, response, blobstore, datastore);
 
     Query query =
@@ -101,26 +105,17 @@ public class ClubServletTest {
     Assert.assertEquals(STUDENT_LIST, clubEntity.getProperty(Constants.MEMBER_PROP));
     Assert.assertEquals(STUDENT_LIST, clubEntity.getProperty(Constants.OFFICER_PROP));
 
-    Mockito.verify(response).sendRedirect(VALID_URL);
+    Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=true");
   }
 
   @Test
   public void doPost_registerNewInvalidClub() throws ServletException, IOException {
-    helper.setEnvEmail(TEST_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
-    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn(SAMPLE_CLUB_NAME);
-    when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn(SAMPLE_CLUB_DESC_1);
-    when(request.getParameter(Constants.WEBSITE_PROP)).thenReturn(SAMPLE_CLUB_WEB);
-
-    ImmutableList<BlobKey> keys = ImmutableList.of(SAMPLE_BLOB);
-    ImmutableMap<String, List<BlobKey>> blobMap = ImmutableMap.of(Constants.LOGO_PROP, keys);
-    when(blobstore.getUploads(request)).thenReturn(blobMap);
-
     clubServlet.doPostHelper(request, response, blobstore, datastore);
 
-    when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn(SAMPLE_CLUB_DESC_2);
+    when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn("club desc");
     clubServlet.doPostHelper(request, response, blobstore, datastore);
 
-    Mockito.verify(response).sendRedirect(INVALID_URL);
+    Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=false");
     Query query =
         new Query("Club")
             .setFilter(
@@ -133,8 +128,55 @@ public class ClubServletTest {
   }
 
   @Test
-  public void doGet_fetchClubExists() throws ServletException, IOException {}
+  public void doGet_clubExists() throws ServletException, IOException {
+    ImmutableList<String> expectedMembers =
+        ImmutableList.of("student@example.com", "officer@example.com");
+    ImmutableList<String> expectedOfficers = ImmutableList.of("officer@example.com");
+    ImmutableList<String> expectedAnnouncements = ImmutableList.of("an announcement");
+
+    Entity clubEnt = new Entity("Club");
+    clubEnt.setProperty(Constants.PROPERTY_NAME, SAMPLE_CLUB_NAME);
+    clubEnt.setProperty(Constants.DESCRIP_PROP, "test description");
+    clubEnt.setProperty(Constants.MEMBER_PROP, expectedMembers);
+    clubEnt.setProperty(Constants.OFFICER_PROP, expectedOfficers);
+    clubEnt.setProperty(Constants.WEBSITE_PROP, "website.com");
+    clubEnt.setProperty(Constants.ANNOUNCE_PROP, expectedAnnouncements);
+    datastore.put(clubEnt);
+
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(printWriter);
+    clubServlet.doGet(request, response);
+
+    String responseStr = stringWriter.toString().trim();
+    JsonElement responseJsonElement = new JsonParser().parse(responseStr);
+    JsonObject response = responseJsonElement.getAsJsonObject();
+
+    ImmutableList<String> actualMembers = convertJsonList(response.get(Constants.MEMBER_PROP));
+    ImmutableList<String> actualOfficers = convertJsonList(response.get(Constants.OFFICER_PROP));
+    ImmutableList<String> acutalAnnouncements =
+        convertJsonList(response.get(Constants.ANNOUNCE_PROP));
+
+    Assert.assertEquals(SAMPLE_CLUB_NAME, response.get(Constants.PROPERTY_NAME).getAsString());
+    Assert.assertEquals("test description", response.get(Constants.DESCRIP_PROP).getAsString());
+    Assert.assertEquals(expectedMembers, actualMembers);
+    Assert.assertEquals(expectedOfficers, actualOfficers);
+    Assert.assertEquals("website.com", response.get(Constants.WEBSITE_PROP).getAsString());
+    Assert.assertEquals(expectedAnnouncements, acutalAnnouncements);
+  }
+
+  private ImmutableList<String> convertJsonList(JsonElement responseProp) {
+    ImmutableList<String> converted =
+        Streams.stream(responseProp.getAsJsonArray())
+            .map(element -> element.toString().replaceAll("\"", ""))
+            .collect(toImmutableList());
+    return converted;
+  }
 
   @Test
-  public void doGet_fetchClubDoesNotExist() throws ServletException, IOException {}
+  public void doGet_clubDoesNotExist() throws ServletException, IOException {
+    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn("Imaginary Club");
+    clubServlet.doGet(request, response);
+    Mockito.verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+  }
 }

--- a/capstone/src/test/java/com/google/sps/clubs/ClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/clubs/ClubServletTest.java
@@ -75,7 +75,7 @@ public class ClubServletTest {
   @Test
   public void doPost_registerNewValidClub() throws ServletException, IOException {
     helper.setEnvEmail(TEST_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
-    when(request.getParameter(Constants.CLUB_NAME_PROP)).thenReturn(SAMPLE_CLUB_NAME);
+    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn(SAMPLE_CLUB_NAME);
     when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn(SAMPLE_CLUB_DESC_1);
     when(request.getParameter(Constants.WEBSITE_PROP)).thenReturn(SAMPLE_CLUB_WEB);
 
@@ -89,12 +89,12 @@ public class ClubServletTest {
         new Query("Club")
             .setFilter(
                 new FilterPredicate(
-                    Constants.CLUB_NAME_PROP,
+                    Constants.PROPERTY_NAME,
                     FilterOperator.EQUAL,
-                    request.getParameter(Constants.CLUB_NAME_PROP)));
+                    request.getParameter(Constants.PROPERTY_NAME)));
     Entity clubEntity = datastore.prepare(query).asSingleEntity();
 
-    Assert.assertEquals(SAMPLE_CLUB_NAME, clubEntity.getProperty(Constants.CLUB_NAME_PROP));
+    Assert.assertEquals(SAMPLE_CLUB_NAME, clubEntity.getProperty(Constants.PROPERTY_NAME));
     Assert.assertEquals(SAMPLE_CLUB_DESC_1, clubEntity.getProperty(Constants.DESCRIP_PROP));
     Assert.assertEquals(SAMPLE_CLUB_WEB, clubEntity.getProperty(Constants.WEBSITE_PROP));
     Assert.assertEquals(SAMPLE_BLOB, clubEntity.getProperty(Constants.LOGO_PROP));
@@ -107,7 +107,7 @@ public class ClubServletTest {
   @Test
   public void doPost_registerNewInvalidClub() throws ServletException, IOException {
     helper.setEnvEmail(TEST_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
-    when(request.getParameter(Constants.CLUB_NAME_PROP)).thenReturn(SAMPLE_CLUB_NAME);
+    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn(SAMPLE_CLUB_NAME);
     when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn(SAMPLE_CLUB_DESC_1);
     when(request.getParameter(Constants.WEBSITE_PROP)).thenReturn(SAMPLE_CLUB_WEB);
 
@@ -125,9 +125,9 @@ public class ClubServletTest {
         new Query("Club")
             .setFilter(
                 new FilterPredicate(
-                    Constants.CLUB_NAME_PROP,
+                    Constants.PROPERTY_NAME,
                     FilterOperator.EQUAL,
-                    request.getParameter(Constants.CLUB_NAME_PROP)));
+                    request.getParameter(Constants.PROPERTY_NAME)));
     Entity clubEntity = datastore.prepare(query).asSingleEntity();
     Assert.assertEquals(SAMPLE_CLUB_DESC_1, clubEntity.getProperty(Constants.DESCRIP_PROP));
   }

--- a/capstone/src/test/java/com/google/sps/clubs/ClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/clubs/ClubServletTest.java
@@ -131,4 +131,10 @@ public class ClubServletTest {
     Entity clubEntity = datastore.prepare(query).asSingleEntity();
     Assert.assertEquals(SAMPLE_CLUB_DESC_1, clubEntity.getProperty(Constants.DESCRIP_PROP));
   }
+
+  @Test
+  public void doGet_fetchClubExists() throws ServletException, IOException {}
+
+  @Test
+  public void doGet_fetchClubDoesNotExist() throws ServletException, IOException {}
 }

--- a/capstone/src/test/java/com/google/sps/clubs/ClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/clubs/ClubServletTest.java
@@ -69,15 +69,6 @@ public class ClubServletTest {
     this.blobstoreServlet = new BlobstoreServlet();
     datastore = DatastoreServiceFactory.getDatastoreService();
     blobstore = Mockito.mock(BlobstoreService.class);
-
-    helper.setEnvEmail(TEST_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
-    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn(SAMPLE_CLUB_NAME);
-    when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn(SAMPLE_CLUB_DESC_1);
-    when(request.getParameter(Constants.WEBSITE_PROP)).thenReturn(SAMPLE_CLUB_WEB);
-
-    ImmutableList<BlobKey> keys = ImmutableList.of(SAMPLE_BLOB);
-    ImmutableMap<String, List<BlobKey>> blobMap = ImmutableMap.of(Constants.LOGO_PROP, keys);
-    when(blobstore.getUploads(request)).thenReturn(blobMap);
   }
 
   @After
@@ -87,6 +78,7 @@ public class ClubServletTest {
 
   @Test
   public void doPost_registerNewValidClub() throws ServletException, IOException {
+    doPost_helper();
     clubServlet.doPostHelper(request, response, blobstore, datastore);
 
     Query query =
@@ -110,6 +102,7 @@ public class ClubServletTest {
 
   @Test
   public void doPost_registerNewInvalidClub() throws ServletException, IOException {
+    doPost_helper();
     clubServlet.doPostHelper(request, response, blobstore, datastore);
 
     when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn("club desc");
@@ -129,19 +122,20 @@ public class ClubServletTest {
 
   @Test
   public void doGet_clubExists() throws ServletException, IOException {
+    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn(SAMPLE_CLUB_NAME);
     ImmutableList<String> expectedMembers =
         ImmutableList.of("student@example.com", "officer@example.com");
     ImmutableList<String> expectedOfficers = ImmutableList.of("officer@example.com");
     ImmutableList<String> expectedAnnouncements = ImmutableList.of("an announcement");
 
-    Entity clubEnt = new Entity("Club");
-    clubEnt.setProperty(Constants.PROPERTY_NAME, SAMPLE_CLUB_NAME);
-    clubEnt.setProperty(Constants.DESCRIP_PROP, "test description");
-    clubEnt.setProperty(Constants.MEMBER_PROP, expectedMembers);
-    clubEnt.setProperty(Constants.OFFICER_PROP, expectedOfficers);
-    clubEnt.setProperty(Constants.WEBSITE_PROP, "website.com");
-    clubEnt.setProperty(Constants.ANNOUNCE_PROP, expectedAnnouncements);
-    datastore.put(clubEnt);
+    Entity clubEntity = new Entity("Club");
+    clubEntity.setProperty(Constants.PROPERTY_NAME, SAMPLE_CLUB_NAME);
+    clubEntity.setProperty(Constants.DESCRIP_PROP, "test description");
+    clubEntity.setProperty(Constants.MEMBER_PROP, expectedMembers);
+    clubEntity.setProperty(Constants.OFFICER_PROP, expectedOfficers);
+    clubEntity.setProperty(Constants.WEBSITE_PROP, "website.com");
+    clubEntity.setProperty(Constants.ANNOUNCE_PROP, expectedAnnouncements);
+    datastore.put(clubEntity);
 
     StringWriter stringWriter = new StringWriter();
     PrintWriter printWriter = new PrintWriter(stringWriter);
@@ -165,6 +159,13 @@ public class ClubServletTest {
     Assert.assertEquals(expectedAnnouncements, acutalAnnouncements);
   }
 
+  @Test
+  public void doGet_clubDoesNotExist() throws ServletException, IOException {
+    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn("Imaginary Club");
+    clubServlet.doGet(request, response);
+    Mockito.verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+  }
+
   private ImmutableList<String> convertJsonList(JsonElement responseProp) {
     ImmutableList<String> converted =
         Streams.stream(responseProp.getAsJsonArray())
@@ -173,10 +174,14 @@ public class ClubServletTest {
     return converted;
   }
 
-  @Test
-  public void doGet_clubDoesNotExist() throws ServletException, IOException {
-    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn("Imaginary Club");
-    clubServlet.doGet(request, response);
-    Mockito.verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+  private void doPost_helper() {
+    helper.setEnvEmail(TEST_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
+    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn(SAMPLE_CLUB_NAME);
+    when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn(SAMPLE_CLUB_DESC_1);
+    when(request.getParameter(Constants.WEBSITE_PROP)).thenReturn(SAMPLE_CLUB_WEB);
+
+    ImmutableList<BlobKey> keys = ImmutableList.of(SAMPLE_BLOB);
+    ImmutableMap<String, List<BlobKey>> blobMap = ImmutableMap.of(Constants.LOGO_PROP, keys);
+    when(blobstore.getUploads(request)).thenReturn(blobMap);
   }
 }

--- a/capstone/src/test/java/com/google/sps/servlets/announcements/AnnouncementsServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/announcements/AnnouncementsServletTest.java
@@ -100,7 +100,7 @@ public final class AnnouncementsServletTest {
   @Test
   public void clubHasNoAnnouncements() throws IOException {
     helper.setEnvEmail("kshao").setEnvAuthDomain("gmail.com").setEnvIsLoggedIn(true);
-    when(request.getParameter(Constants.CLUB_NAME_PROP)).thenReturn(CLUB_2);
+    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn(CLUB_2);
 
     JsonArray response = getServletResponse(servlet);
 
@@ -111,7 +111,7 @@ public final class AnnouncementsServletTest {
   @Test
   public void clubHasOnlyOneAnnouncement() throws IOException {
     helper.setEnvEmail("kshao").setEnvAuthDomain("gmail.com").setEnvIsLoggedIn(true);
-    when(request.getParameter(Constants.CLUB_NAME_PROP)).thenReturn(CLUB_1);
+    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn(CLUB_1);
 
     JsonArray response = getServletResponse(servlet);
 


### PR DESCRIPTION
Club information displayed on about us info page fetches from datastore rather than from PrototypeClubs.java. Gets corresponding Club Entity from datastore, then builds its Club Object. Adds tests to confirm behavior when the queried club name is valid (exists in datastore) and invalid (does not exist in datastore).