### PR TITLE
Load profile inbox from Datastore

### DIFF
--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -17,4 +17,9 @@ class Constants {
   static final String OFFICER_PROP = "officers";
   static final String ANNOUNCE_PROP = "announcements";
   static final int LOAD_LIMIT = 10;
+  static final String CLUB_PROP = "club";
+  static final String ANNOUNCEMENT_PROP = "Announcement";
+  static final String AUTHOR_PROP = "author";
+  static final String TIME_PROP = "time";
+  static final String CONTENT_PROP = "content";
 }

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
@@ -25,8 +25,6 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/announcements")
 public class AnnouncementsServlet extends HttpServlet {
 
-  private static final String ANNOUNCEMENTS_CONTENT_PROP = "content";
-
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     // Get announcements object based on the logged in email
@@ -64,7 +62,7 @@ public class AnnouncementsServlet extends HttpServlet {
     UserService userService = UserServiceFactory.getUserService();
     String userEmail = userService.getCurrentUser().getEmail();
     String clubName = request.getParameter(Constants.CLUB_NAME_PROP);
-    String announcementContent = request.getParameter(ANNOUNCEMENTS_CONTENT_PROP);
+    String announcementContent = request.getParameter(Constants.CONTENT_PROP);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     // TODO need to authenticate user as club officer

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
@@ -26,11 +26,6 @@ import javax.servlet.http.HttpServletResponse;
 public class AnnouncementsServlet extends HttpServlet {
 
   private static final String ANNOUNCEMENTS_CONTENT_PROP = "content";
-  private static final String ANNOUNCEMENT_PROP = "Announcement";
-  private static final String AUTHOR_PROP = "author";
-  private static final String TIME_PROP = "time";
-  private static final String CONTENT_PROP = "content";
-  private static final String CLUB_PROP = "club";
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -41,8 +36,8 @@ public class AnnouncementsServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Query query =
-        new Query(ANNOUNCEMENT_PROP)
-            .setFilter(new FilterPredicate(CLUB_PROP, FilterOperator.EQUAL, clubName))
+        new Query(Constants.ANNOUNCEMENT_PROP)
+            .setFilter(new FilterPredicate(Constants.CLUB_PROP, FilterOperator.EQUAL, clubName))
             .addSort("time", SortDirection.DESCENDING);
     PreparedQuery results = datastore.prepare(query);
     ImmutableList<Announcement> announcements =
@@ -74,11 +69,11 @@ public class AnnouncementsServlet extends HttpServlet {
 
     // TODO need to authenticate user as club officer
 
-    Entity announcementEntity = new Entity(ANNOUNCEMENT_PROP);
-    announcementEntity.setProperty(AUTHOR_PROP, userEmail);
-    announcementEntity.setProperty(TIME_PROP, System.currentTimeMillis());
-    announcementEntity.setProperty(CONTENT_PROP, announcementContent);
-    announcementEntity.setProperty(CLUB_PROP, clubName);
+    Entity announcementEntity = new Entity(Constants.ANNOUNCEMENT_PROP);
+    announcementEntity.setProperty(Constants.AUTHOR_PROP, userEmail);
+    announcementEntity.setProperty(Constants.TIME_PROP, System.currentTimeMillis());
+    announcementEntity.setProperty(Constants.CONTENT_PROP, announcementContent);
+    announcementEntity.setProperty(Constants.CLUB_PROP, clubName);
 
     datastore.put(announcementEntity);
 

--- a/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
@@ -122,7 +122,7 @@ public class StudentServlet extends HttpServlet {
   }
 
   private ImmutableList<String> getClubAnnouncements(String clubName, DatastoreService datastore) {
-    // Get all announcements from given club name
+    // Get all announcements from given club name in reverse chronological order
     Query query =
         new Query(Constants.ANNOUNCEMENT_PROP)
             .setFilter(new FilterPredicate(Constants.CLUB_PROP, FilterOperator.EQUAL, clubName))

--- a/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
@@ -151,13 +151,12 @@ public class StudentServlet extends HttpServlet {
     String time = formatDate.format(calendar.getTime());
 
     String fullAnnouncement =
-        announcement.getProperty(Constants.CONTENT_PROP).toString()
-            + " from "
-            + announcement.getProperty(Constants.AUTHOR_PROP)
-            + " in "
-            + announcement.getProperty(Constants.CLUB_PROP).toString()
-            + " sent at "
-            + time;
+        String.format(
+            "%1$s from %2$s in %3$s sent at %4$s",
+            announcement.getProperty(Constants.CONTENT_PROP),
+            announcement.getProperty(Constants.AUTHOR_PROP),
+            announcement.getProperty(Constants.CLUB_PROP),
+            time);
     return fullAnnouncement;
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet that returns a student's profile content */
 @WebServlet("/student-data")
 public class StudentServlet extends HttpServlet {
+  private static String TIMEZONE_PST = "PST";
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -132,15 +133,14 @@ public class StudentServlet extends HttpServlet {
     // Stream through results and get formatted announcements
     ImmutableList<String> announcements =
         Streams.stream(results.asIterable())
-            .limit(Constants.LOAD_LIMIT)
-            .map(entity -> getAnnouncementAsString(entity))
+            .map(StudentServlet::getAnnouncementAsString)
             .collect(toImmutableList());
     return announcements;
   }
 
-  private String getAnnouncementAsString(Entity announcement) {
+  private static String getAnnouncementAsString(Entity announcement) {
     // Set calendar timezone and time
-    TimeZone timePST = TimeZone.getTimeZone("PST");
+    TimeZone timePST = TimeZone.getTimeZone(TIMEZONE_PST);
     Calendar calendar = Calendar.getInstance(timePST);
     calendar.setTimeInMillis(
         Long.parseLong(announcement.getProperty(Constants.TIME_PROP).toString()));

--- a/capstone/src/test/java/com/google/sps/servlets/student/StudentServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/student/StudentServletTest.java
@@ -256,13 +256,12 @@ public final class StudentServletTest {
     String time = formatDate.format(new Date(System.currentTimeMillis()));
 
     String fullAnnouncement =
-        announcement.getProperty(Constants.CONTENT_PROP)
-            + " from "
-            + announcement.getProperty(Constants.AUTHOR_PROP)
-            + " in "
-            + announcement.getProperty(Constants.CLUB_PROP)
-            + " sent at "
-            + time;
+        String.format(
+            "%1$s from %2$s in %3$s sent at %4$s",
+            announcement.getProperty(Constants.CONTENT_PROP),
+            announcement.getProperty(Constants.AUTHOR_PROP),
+            announcement.getProperty(Constants.CLUB_PROP),
+            time);
     return fullAnnouncement;
   }
 }


### PR DESCRIPTION
This branch adds code to load the announcements inbox on the profile page from Datastore instead of from the hard-coded clubs map. The announcements are now formatted to include all necessary information such as the content, author, club, and time that the announcement was posted and/or sent. 