### PR TITLE
Transition to using datastore for the explore servlet

### DIFF
--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -4,6 +4,7 @@ package com.google.sps.servlets;
 class Constants {
   private Constants() {}
 
+  static final String CLUB_PROP = "Club";
   static final String CLUB_NAME_PROP = "name";
   static final String PROPERTY_NAME = "name";
   static final String PROPERTY_EMAIL = "email";

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -45,6 +45,6 @@ public class ExploreServlet extends HttpServlet {
         ImmutableList.copyOf((List<String>) entity.getProperty(Constants.OFFICER_PROP)),
         entity.getProperty(Constants.DESCRIP_PROP).toString(),
         entity.getProperty(Constants.WEBSITE_PROP).toString(),
-        null);
+        null); // announcements = null, unnecessary due to change in data structure
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -1,8 +1,16 @@
 package com.google.sps.servlets;
 
-import com.google.common.collect.ImmutableCollection;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
 import com.google.gson.Gson;
 import java.io.IOException;
+import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -14,7 +22,26 @@ public class ExploreServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Gson gson = new Gson();
-    ImmutableCollection<Club> clubs = PrototypeClubs.PROTOTYPE_CLUBS_MAP.values();
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    Query query = new Query(Constants.CLUB_PROP);
+    PreparedQuery results = datastore.prepare(query);
+    ImmutableList<Club> clubs =
+        Streams.stream(results.asIterable())
+            .limit(Constants.LOAD_LIMIT)
+            .map(
+                entity ->
+                    new Club(
+                        entity.getProperty(Constants.CLUB_NAME_PROP).toString(),
+                        ImmutableList.copyOf(
+                            (List<String>) entity.getProperty(Constants.MEMBER_PROP)),
+                        ImmutableList.copyOf(
+                            (List<String>) entity.getProperty(Constants.OFFICER_PROP)),
+                        entity.getProperty(Constants.DESCRIP_PROP).toString(),
+                        entity.getProperty(Constants.WEBSITE_PROP).toString(),
+                        null))
+            .collect(toImmutableList());
+
     String json = gson.toJson(clubs);
     response.setContentType("application/json;");
     response.getWriter().println(json);

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -4,6 +4,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.common.collect.ImmutableList;
@@ -29,21 +30,21 @@ public class ExploreServlet extends HttpServlet {
     ImmutableList<Club> clubs =
         Streams.stream(results.asIterable())
             .limit(Constants.LOAD_LIMIT)
-            .map(
-                entity ->
-                    new Club(
-                        entity.getProperty(Constants.CLUB_NAME_PROP).toString(),
-                        ImmutableList.copyOf(
-                            (List<String>) entity.getProperty(Constants.MEMBER_PROP)),
-                        ImmutableList.copyOf(
-                            (List<String>) entity.getProperty(Constants.OFFICER_PROP)),
-                        entity.getProperty(Constants.DESCRIP_PROP).toString(),
-                        entity.getProperty(Constants.WEBSITE_PROP).toString(),
-                        null))
+            .map(entity -> createClubFromEntity(entity))
             .collect(toImmutableList());
 
     String json = gson.toJson(clubs);
     response.setContentType("application/json;");
     response.getWriter().println(json);
+  }
+
+  private Club createClubFromEntity(Entity entity) {
+    return new Club(
+        entity.getProperty(Constants.CLUB_NAME_PROP).toString(),
+        ImmutableList.copyOf((List<String>) entity.getProperty(Constants.MEMBER_PROP)),
+        ImmutableList.copyOf((List<String>) entity.getProperty(Constants.OFFICER_PROP)),
+        entity.getProperty(Constants.DESCRIP_PROP).toString(),
+        entity.getProperty(Constants.WEBSITE_PROP).toString(),
+        null);
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -55,7 +55,7 @@ public class ClubServlet extends HttpServlet {
 
     // Check if club name is valid
     Query query =
-        new Query("Club")
+        new Query(Constants.CLUB_PROP)
             .setFilter(
                 new FilterPredicate(
                     Constants.CLUB_NAME_PROP,

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -72,7 +72,7 @@ public class ClubServlet extends HttpServlet {
       String website = request.getParameter(Constants.WEBSITE_PROP);
       BlobKey key = getBlobKey(request, Constants.LOGO_PROP, blobstore);
 
-      Entity clubEntity = new Entity("Club", clubName);
+      Entity clubEntity = new Entity(Constants.CLUB_PROP, clubName);
       clubEntity.setProperty(Constants.CLUB_NAME_PROP, clubName);
       clubEntity.setProperty(Constants.DESCRIP_PROP, description);
       clubEntity.setProperty(Constants.WEBSITE_PROP, website);

--- a/capstone/src/main/webapp/club-registration.html
+++ b/capstone/src/main/webapp/club-registration.html
@@ -9,7 +9,7 @@
   <body onload="fetchBlobstoreUrl()">
     <div id="navbar"></div>
     <h2>Club Registration</h2>
-    <form id="club-form" class="full-screen-panel" method="POST" enctype="multipart/form-data">
+    <form id="club-form" class="full-screen-panel" action="/clubs" method="POST" enctype="multipart/form-data">
       <div class="form-group">
         <label for="name">Name:</label>
         <input type="text" name="name" id="club-name">

--- a/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
@@ -41,7 +41,10 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-/** */
+/**
+ * Class to test ExploreServlet by adding a few mock clubs and ensuring their existence and
+ * properties
+ */
 @RunWith(JUnit4.class)
 public final class ExploreServletTest {
 
@@ -64,9 +67,6 @@ public final class ExploreServletTest {
   @Mock private HttpServletResponse response;
   private DatastoreService datastore;
 
-  private Entity club1;
-  private Entity club2;
-
   private LocalServiceTestHelper helper =
       new LocalServiceTestHelper(
           new LocalDatastoreServiceTestConfig(),
@@ -79,23 +79,6 @@ public final class ExploreServletTest {
     MockitoAnnotations.initMocks(this);
     helper.setUp();
     this.datastore = DatastoreServiceFactory.getDatastoreService();
-
-    club1 = new Entity(Constants.CLUB_PROP);
-    club1.setProperty(Constants.CLUB_NAME_PROP, CLUB_1);
-    club1.setProperty(Constants.MEMBER_PROP, ImmutableList.of(MEGHA, MEGAN, KEVIN));
-    club1.setProperty(Constants.OFFICER_PROP, ImmutableList.of(MEGHA));
-    club1.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_1);
-    club1.setProperty(Constants.WEBSITE_PROP, SITE_1);
-
-    club2 = new Entity(Constants.CLUB_PROP);
-    club2.setProperty(Constants.CLUB_NAME_PROP, CLUB_2);
-    club2.setProperty(Constants.MEMBER_PROP, ImmutableList.of(KEVIN));
-    club2.setProperty(Constants.OFFICER_PROP, ImmutableList.of(KEVIN));
-    club2.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_2);
-    club2.setProperty(Constants.WEBSITE_PROP, SITE_2);
-
-    this.datastore.put(club1);
-    this.datastore.put(club2);
   }
 
   @After
@@ -107,6 +90,23 @@ public final class ExploreServletTest {
   public void correctNumberReturned() throws IOException {
     helper.setEnvEmail("kshao").setEnvAuthDomain("gmail.com").setEnvIsLoggedIn(true);
     when(request.getParameter(Constants.CLUB_NAME_PROP)).thenReturn(CLUB_2);
+
+    Entity club1 = new Entity(Constants.CLUB_PROP);
+    club1.setProperty(Constants.CLUB_NAME_PROP, CLUB_1);
+    club1.setProperty(Constants.MEMBER_PROP, ImmutableList.of(MEGHA, MEGAN, KEVIN));
+    club1.setProperty(Constants.OFFICER_PROP, ImmutableList.of(MEGHA));
+    club1.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_1);
+    club1.setProperty(Constants.WEBSITE_PROP, SITE_1);
+
+    Entity club2 = new Entity(Constants.CLUB_PROP);
+    club2.setProperty(Constants.CLUB_NAME_PROP, CLUB_2);
+    club2.setProperty(Constants.MEMBER_PROP, ImmutableList.of(KEVIN));
+    club2.setProperty(Constants.OFFICER_PROP, ImmutableList.of(KEVIN));
+    club2.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_2);
+    club2.setProperty(Constants.WEBSITE_PROP, SITE_2);
+
+    this.datastore.put(club1);
+    this.datastore.put(club2);
 
     JsonArray response = getServletResponse(servlet);
 

--- a/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
@@ -1,0 +1,129 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import static org.mockito.Mockito.when;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.development.testing.LocalURLFetchServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import com.google.common.collect.ImmutableList;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** */
+@RunWith(JUnit4.class)
+public final class ExploreServletTest {
+
+  private static final String KEVIN = "kshao@google.com";
+  private static final String MEGHA = "kakm@google.com";
+  private static final String MEGAN = "meganshi@google.com";
+
+  private static final String CLUB_1 = "Club 1";
+  private static final String CLUB_2 = "Club 2";
+  private static final String CLUB_3 = "Club 3";
+
+  private static final String SITE_1 = "www.fakesite.com";
+  private static final String SITE_2 = "www.realfakesite.com";
+
+  private static final String DESCRIPTION_1 = "Helping people.";
+  private static final String DESCRIPTION_2 = "Not helping people.";
+
+  private ExploreServlet servlet;
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  private DatastoreService datastore;
+
+  private Entity club1;
+  private Entity club2;
+
+  private LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          new LocalDatastoreServiceTestConfig(),
+          new LocalUserServiceTestConfig(),
+          new LocalURLFetchServiceTestConfig());
+
+  @Before
+  public void setUp() {
+    this.servlet = new ExploreServlet();
+    MockitoAnnotations.initMocks(this);
+    helper.setUp();
+    this.datastore = DatastoreServiceFactory.getDatastoreService();
+
+    club1 = new Entity(Constants.CLUB_PROP);
+    club1.setProperty(Constants.CLUB_NAME_PROP, CLUB_1);
+    club1.setProperty(Constants.MEMBER_PROP, ImmutableList.of(MEGHA, MEGAN, KEVIN));
+    club1.setProperty(Constants.OFFICER_PROP, ImmutableList.of(MEGHA));
+    club1.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_1);
+    club1.setProperty(Constants.WEBSITE_PROP, SITE_1);
+
+    club2 = new Entity(Constants.CLUB_PROP);
+    club2.setProperty(Constants.CLUB_NAME_PROP, CLUB_2);
+    club2.setProperty(Constants.MEMBER_PROP, ImmutableList.of(KEVIN));
+    club2.setProperty(Constants.OFFICER_PROP, ImmutableList.of(KEVIN));
+    club2.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_2);
+    club2.setProperty(Constants.WEBSITE_PROP, SITE_2);
+
+    this.datastore.put(club1);
+    this.datastore.put(club2);
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void correctNumberReturned() throws IOException {
+    helper.setEnvEmail("kshao").setEnvAuthDomain("gmail.com").setEnvIsLoggedIn(true);
+    when(request.getParameter(Constants.CLUB_NAME_PROP)).thenReturn(CLUB_2);
+
+    JsonArray response = getServletResponse(servlet);
+
+    int expectedSize = 2;
+    Assert.assertEquals(expectedSize, response.size());
+  }
+
+  private JsonArray getServletResponse(ExploreServlet servlet) throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(printWriter);
+
+    servlet.doGet(request, response);
+
+    String responseStr = stringWriter.toString().trim();
+    JsonElement responseJsonElement = new JsonParser().parse(responseStr);
+
+    return responseJsonElement.getAsJsonArray();
+  }
+}


### PR DESCRIPTION
This PR contains all necessary changes for allowing the explore servlet to draw from Datastore instead of the hard-coded clubs. In order to test this, the club registration page is linked to the club servlet page, and tests were written to ensure the functionality of the new Explore servlet. 