### PR TITLE
Add "Join Club" button functionality with Datastore

### DIFF
--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -21,4 +21,5 @@ class Constants {
   static final String AUTHOR_PROP = "author";
   static final String TIME_PROP = "time";
   static final String CONTENT_PROP = "content";
+  static final String JOIN_CLUB_PROP = "join";
 }

--- a/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
@@ -190,7 +190,7 @@ public class StudentServlet extends HttpServlet {
 
   private void addItemToEntity(
       Entity entity, DatastoreService datastore, String itemToAdd, String property) {
-    // Create emtpy List if property does not exist yet
+    // Create empty List if property does not exist yet
     List<String> generalList = new ArrayList<String>();
     if (entity.getProperty(property) != null) {
       generalList = ((ArrayList<String>) entity.getProperty(property));

--- a/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
@@ -100,7 +100,14 @@ public class StudentServlet extends HttpServlet {
     UserService userService = UserServiceFactory.getUserService();
     String userEmail = userService.getCurrentUser().getEmail();
 
-    response.sendRedirect("/profile.html");
+    // Remove club from student's club list
+    String joinedClub = request.getParameter("join");
+    if (joinedClub != null && !joinedClub.isEmpty()) {
+      System.out.println("here: " + joinedClub);
+      response.sendRedirect("index.html");
+    } else {
+      response.sendRedirect("profile.html");
+    }
   }
 
   private Entity createStudentEntity(String userEmail) {

--- a/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
@@ -103,7 +103,7 @@ public class StudentServlet extends HttpServlet {
     Entity student = ImmutableList.copyOf(results.asIterable()).get(0);
 
     // Remove club from student's club list
-    String clubToJoin = request.getParameter("join");
+    String clubToJoin = request.getParameter(Constants.JOIN_CLUB_PROP);
     if (clubToJoin != null && !clubToJoin.isEmpty()) {
       // Get student's current club list and add new club
       ArrayList<String> clubList = new ArrayList<String>();

--- a/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
@@ -102,7 +102,7 @@ public class StudentServlet extends HttpServlet {
     PreparedQuery results = datastore.prepare(query);
     Entity student = ImmutableList.copyOf(results.asIterable()).get(0);
 
-    // Remove club from student's club list
+    // Add club to student's club list
     String clubToJoin = request.getParameter(Constants.JOIN_CLUB_PROP);
     if (clubToJoin != null && !clubToJoin.isEmpty()) {
       // Get student's current club list and add new club

--- a/capstone/src/main/webapp/explore-loader.js
+++ b/capstone/src/main/webapp/explore-loader.js
@@ -15,8 +15,15 @@ function loadListings (json) {
     template.content.querySelector('#club-name').href = 'about-us.html?name=' + club.name;
     template.content.querySelector('#description').innerHTML = club.description;
     template.content.querySelector('#members').innerHTML = club.members.length + ' members';
+    template.content.querySelector("#club-join-container").innerHTML = getJoinButton(club.name);    
     var clone = document.importNode(template.content, true);
-    document.getElementById('club-listings').appendChild(clone);    
+    document.getElementById('club-listings').appendChild(clone);
   }
 }
 
+function getJoinButton(clubName) {
+  var joinButton = '<button name="join" value="'
+    + clubName
+    + '" formmethod="POST">Join Club</button>';
+  return joinButton;
+}

--- a/capstone/src/main/webapp/index.html
+++ b/capstone/src/main/webapp/index.html
@@ -21,9 +21,7 @@
             <p id="description"></p>
             <p id="members"></p>
           </div> 
-          <div class="club-join-container">
-            <button onclick="location.href='about-us.html';">Join club</button>
-          </div>
+          <form id="club-join-container" name="join" action="/student-data" method="POST"></form>
         </template>
       </div>
       <button id="register-club-button" onclick="location.href='club-registration.html';">Register a new club!</button>

--- a/capstone/src/main/webapp/profile-loader.js
+++ b/capstone/src/main/webapp/profile-loader.js
@@ -66,7 +66,7 @@ function createClubElement(text) {
 
   // Create leave button and set value to its respective club
   liElement.innerHTML += text
-    + '  <button name="club" value="'
+    + '  <button name="leave" value="'
     + text
     + '" formmethod="POST">Leave</button>';
   return liElement;

--- a/capstone/src/main/webapp/profile.html
+++ b/capstone/src/main/webapp/profile.html
@@ -16,7 +16,7 @@
       <div class="split-profile left-profile">
         <h1><u>Profile</u></h1>
         <h2>My Clubs:</h2>
-        <form name="club" action="/student-data" method="GET">
+        <form name="leave" action="/student-data" method="GET">
           <ul id="club-content"></ul>
         </form>
         <br>

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -98,10 +98,6 @@ function showTab(tabName) {
   }
 }
 
-/** Adds student to members list for current club */
-function joinClub() {
-}
-
 /** Fetches blobstore image upload url. */
 async function fetchBlobstoreUrl() {
   fetch('/blobstore-url')

--- a/capstone/src/main/webapp/style.css
+++ b/capstone/src/main/webapp/style.css
@@ -107,7 +107,7 @@ button {
 
 .club-logo-container, 
 .club-info-container, 
-.club-join-container {
+#club-join-container {
   display: inline-block;
   padding: 5px;
   vertical-align: middle;
@@ -122,7 +122,7 @@ button {
   width: 60%;
 }
 
-.club-join-container {
+#club-join-container {
   width: 20%;
 }
 

--- a/capstone/src/test/java/com/google/sps/servlets/student/StudentServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/student/StudentServletTest.java
@@ -58,6 +58,8 @@ public final class StudentServletTest {
   private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
   private Entity studentMegan;
   private Entity studentMegha;
+  private Entity club1;
+  private Entity club2;
 
   @Before
   public void setUp() throws Exception {
@@ -77,6 +79,14 @@ public final class StudentServletTest {
     studentMegha.setProperty(Constants.PROPERTY_GRADYEAR, YEAR_2022);
     studentMegha.setProperty(Constants.PROPERTY_MAJOR, MAJOR);
     studentMegha.setProperty(Constants.PROPERTY_CLUBS, ImmutableList.of());
+
+    club1 = new Entity("Club");
+    club1.setProperty(Constants.PROPERTY_NAME, CLUB_1);
+    club1.setProperty(Constants.MEMBER_PROP, ImmutableList.of(MEGAN_EMAIL));
+
+    club2 = new Entity("Club");
+    club2.setProperty(Constants.PROPERTY_NAME, CLUB_2);
+    club2.setProperty(Constants.MEMBER_PROP, ImmutableList.of());
   }
 
   @After
@@ -233,6 +243,7 @@ public final class StudentServletTest {
 
   @Test
   public void doPost_studentClicksJoinClub() throws ServletException, IOException {
+    datastore.put(club2);
     datastore.put(studentMegha);
     localHelper.setEnvEmail(MEGHA_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
     when(request.getParameter(Constants.JOIN_CLUB_PROP)).thenReturn(CLUB_2);
@@ -250,6 +261,7 @@ public final class StudentServletTest {
 
   @Test
   public void doPost_studentJoinsClubTheyAreAlreadyIn() throws ServletException, IOException {
+    datastore.put(club1);
     datastore.put(studentMegan);
     localHelper.setEnvEmail(MEGAN_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
     when(request.getParameter(Constants.JOIN_CLUB_PROP)).thenReturn(CLUB_1);

--- a/capstone/src/test/java/com/google/sps/servlets/student/StudentServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/student/StudentServletTest.java
@@ -227,6 +227,18 @@ public final class StudentServletTest {
     Assert.assertTrue(response.isEmpty());
   }
 
+  @Test
+  public void doPost_studentClicksJoinClub() throws ServletException, IOException {
+    datastore.put(studentMegan);
+    localHelper.setEnvEmail(MEGAN_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
+    when(request.getParameter(Constants.JOIN_CLUB_PROP)).thenReturn(CLUB_1);
+    
+    String response = doPost_studentServletResponse();
+    String clubList = studentMegan.getProperty(Constants.PROPERTY_CLUBS).toString();
+
+    Assert.assertEquals(ImmutableList.of(CLUB_1).toString(), clubList);
+  }
+
   private String getAnnouncement(String announcementContent) {
     // Get announcement from test Datastore based on content
     Query query =

--- a/capstone/src/test/java/com/google/sps/servlets/student/StudentServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/student/StudentServletTest.java
@@ -134,7 +134,7 @@ public final class StudentServletTest {
     Assert.assertEquals("First Last", responseName);
     Assert.assertEquals(KEVIN_EMAIL, responseEmail);
     Assert.assertEquals(0, responseYear);
-    Assert.assertEquals("", responseMajor);
+    Assert.assertEquals("Enter your major here", responseMajor);
     Assert.assertEquals(ImmutableList.of(), responseClubs);
   }
 

--- a/capstone/src/test/java/com/google/sps/servlets/student/StudentServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/student/StudentServletTest.java
@@ -55,11 +55,18 @@ public final class StudentServletTest {
   private LocalServiceTestHelper localHelper =
       new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
   private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+  private Entity studentMegan;
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     localHelper.setUp();
+    studentMegan = new Entity(MEGAN_EMAIL);
+    studentMegan.setProperty(Constants.PROPERTY_NAME, MEGAN_NAME);
+    studentMegan.setProperty(Constants.PROPERTY_EMAIL, MEGAN_EMAIL);
+    studentMegan.setProperty(Constants.PROPERTY_GRADYEAR, YEAR_2022);
+    studentMegan.setProperty(Constants.PROPERTY_MAJOR, MAJOR);
+    studentMegan.setProperty(Constants.PROPERTY_CLUBS, ImmutableList.of(CLUB_1));
   }
 
   @After
@@ -143,12 +150,6 @@ public final class StudentServletTest {
 
   @Test
   public void doGet_studentIsInOneClub() throws ServletException, IOException {
-    Entity studentMegan = new Entity(MEGAN_EMAIL);
-    studentMegan.setProperty(Constants.PROPERTY_NAME, MEGAN_NAME);
-    studentMegan.setProperty(Constants.PROPERTY_EMAIL, MEGAN_EMAIL);
-    studentMegan.setProperty(Constants.PROPERTY_GRADYEAR, YEAR_2022);
-    studentMegan.setProperty(Constants.PROPERTY_MAJOR, MAJOR);
-    studentMegan.setProperty(Constants.PROPERTY_CLUBS, ImmutableList.of(CLUB_1));
     datastore.put(studentMegan);
 
     localHelper.setEnvEmail(MEGAN_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
@@ -183,13 +184,6 @@ public final class StudentServletTest {
     announcementEntity.setProperty(Constants.CONTENT_PROP, announcementContent);
     announcementEntity.setProperty(Constants.CLUB_PROP, CLUB_1);
     datastore.put(announcementEntity);
-
-    Entity studentMegan = new Entity(MEGAN_EMAIL);
-    studentMegan.setProperty(Constants.PROPERTY_NAME, MEGAN_NAME);
-    studentMegan.setProperty(Constants.PROPERTY_EMAIL, MEGAN_EMAIL);
-    studentMegan.setProperty(Constants.PROPERTY_GRADYEAR, YEAR_2022);
-    studentMegan.setProperty(Constants.PROPERTY_MAJOR, MAJOR);
-    studentMegan.setProperty(Constants.PROPERTY_CLUBS, ImmutableList.of(CLUB_1));
     datastore.put(studentMegan);
 
     localHelper.setEnvEmail(MEGAN_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
@@ -225,12 +219,6 @@ public final class StudentServletTest {
 
   @Test
   public void doPost_studentIsLoggedIn() throws ServletException, IOException {
-    Entity studentMegan = new Entity(MEGAN_EMAIL);
-    studentMegan.setProperty(Constants.PROPERTY_NAME, MEGAN_NAME);
-    studentMegan.setProperty(Constants.PROPERTY_EMAIL, MEGAN_EMAIL);
-    studentMegan.setProperty(Constants.PROPERTY_GRADYEAR, YEAR_2022);
-    studentMegan.setProperty(Constants.PROPERTY_MAJOR, MAJOR);
-    studentMegan.setProperty(Constants.PROPERTY_CLUBS, ImmutableList.of(CLUB_1));
     datastore.put(studentMegan);
 
     localHelper.setEnvEmail(MEGAN_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);


### PR DESCRIPTION
This branch adds the "Join Club" button functionality to work with Datastore so once the user click on "Join Club," the club is added to the user's club list if it is not already there and updates Datastore. If the user clicks on "Join Club" from the Explore page, then the user will be redirected to the club's About Us page