### PR TITLE
Resolve constants between "Club" and "club"

### DIFF
--- a/capstone/pom.xml
+++ b/capstone/pom.xml
@@ -85,8 +85,7 @@
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>
         <configuration>
-          <!-- TODO: set project ID. -->
-          <deploy.projectId>clubhub-step-2020</deploy.projectId>
+          <deploy.projectId>google.com:clubhub-step-2020</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>

--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -4,7 +4,7 @@ package com.google.sps.servlets;
 class Constants {
   private Constants() {}
 
-  static final String CLUB_PROP = "Club";
+  static final String CLUB_PROP = "club";
   static final String CLUB_NAME_PROP = "name";
   static final String PROPERTY_NAME = "name";
   static final String PROPERTY_EMAIL = "email";
@@ -18,7 +18,7 @@ class Constants {
   static final String OFFICER_PROP = "officers";
   static final String ANNOUNCE_PROP = "announcements";
   static final int LOAD_LIMIT = 10;
-  static final String CLUB_PROP = "club";
+  static final String CLUB_ENTITY_PROP = "Club";
   static final String ANNOUNCEMENT_PROP = "Announcement";
   static final String AUTHOR_PROP = "author";
   static final String TIME_PROP = "time";

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -25,7 +25,7 @@ public class ExploreServlet extends HttpServlet {
     Gson gson = new Gson();
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-    Query query = new Query(Constants.CLUB_PROP);
+    Query query = new Query(Constants.CLUB_ENTITY_PROP);
     PreparedQuery results = datastore.prepare(query);
     ImmutableList<Club> clubs =
         Streams.stream(results.asIterable())

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
@@ -44,10 +44,10 @@ public class AnnouncementsServlet extends HttpServlet {
             .map(
                 entity ->
                     new Announcement(
-                        entity.getProperty("author").toString(),
-                        entity.getProperty("club").toString(),
-                        Long.parseLong(entity.getProperty("time").toString()),
-                        entity.getProperty("content").toString()))
+                        entity.getProperty(Constants.AUTHOR_PROP).toString(),
+                        entity.getProperty(Constants.CLUB_PROP).toString(),
+                        Long.parseLong(entity.getProperty(Constants.TIME_PROP).toString()),
+                        entity.getProperty(Constants.CONTENT_PROP).toString()))
             .collect(toImmutableList());
 
     Gson gson = new Gson();

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -80,7 +80,7 @@ public class ClubServlet extends HttpServlet {
       String website = request.getParameter(Constants.WEBSITE_PROP);
       BlobKey key = getBlobKey(request, Constants.LOGO_PROP, blobstore);
 
-      Entity clubEntity = new Entity(Constants.CLUB_PROP, clubName);
+      Entity clubEntity = new Entity(Constants.CLUB_ENTITY_PROP, clubName);
       clubEntity.setProperty(Constants.CLUB_NAME_PROP, clubName);
       clubEntity.setProperty(Constants.DESCRIP_PROP, description);
       clubEntity.setProperty(Constants.WEBSITE_PROP, website);

--- a/capstone/src/test/java/com/google/sps/clubs/ClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/clubs/ClubServletTest.java
@@ -82,7 +82,7 @@ public class ClubServletTest {
     clubServlet.doPostHelper(request, response, blobstore, datastore);
 
     Query query =
-        new Query("Club")
+        new Query(Constants.CLUB_ENTITY_PROP)
             .setFilter(
                 new FilterPredicate(
                     Constants.PROPERTY_NAME,
@@ -128,7 +128,7 @@ public class ClubServletTest {
     ImmutableList<String> expectedOfficers = ImmutableList.of("officer@example.com");
     ImmutableList<String> expectedAnnouncements = ImmutableList.of("an announcement");
 
-    Entity clubEntity = new Entity("Club");
+    Entity clubEntity = new Entity(Constants.CLUB_ENTITY_PROP);
     clubEntity.setProperty(Constants.PROPERTY_NAME, SAMPLE_CLUB_NAME);
     clubEntity.setProperty(Constants.DESCRIP_PROP, "test description");
     clubEntity.setProperty(Constants.MEMBER_PROP, expectedMembers);

--- a/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
@@ -95,14 +95,14 @@ public final class ExploreServletTest {
     helper.setEnvEmail("kshao").setEnvAuthDomain("gmail.com").setEnvIsLoggedIn(true);
     when(request.getParameter(Constants.CLUB_NAME_PROP)).thenReturn(CLUB_2);
 
-    Entity club1 = new Entity(Constants.CLUB_PROP);
+    Entity club1 = new Entity(Constants.CLUB_ENTITY_PROP);
     club1.setProperty(Constants.CLUB_NAME_PROP, CLUB_1);
     club1.setProperty(Constants.MEMBER_PROP, ImmutableList.of(MEGHA, MEGAN, KEVIN));
     club1.setProperty(Constants.OFFICER_PROP, ImmutableList.of(MEGHA));
     club1.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_1);
     club1.setProperty(Constants.WEBSITE_PROP, SITE_1);
 
-    Entity club2 = new Entity(Constants.CLUB_PROP);
+    Entity club2 = new Entity(Constants.CLUB_ENTITY_PROP);
     club2.setProperty(Constants.CLUB_NAME_PROP, CLUB_2);
     club2.setProperty(Constants.MEMBER_PROP, ImmutableList.of(KEVIN));
     club2.setProperty(Constants.OFFICER_PROP, ImmutableList.of(KEVIN));

--- a/capstone/src/test/java/com/google/sps/servlets/announcements/AnnouncementsServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/announcements/AnnouncementsServletTest.java
@@ -46,10 +46,6 @@ import org.mockito.MockitoAnnotations;
 public final class AnnouncementsServletTest {
 
   private static final String ANNOUNCEMENT_PROP = "Announcement";
-  private static final String AUTHOR_PROP = "author";
-  private static final String TIME_PROP = "time";
-  private static final String CONTENT_PROP = "content";
-  private static final String CLUB_PROP = "club";
 
   private static final String AUTHOR_1 = "kshao@google.com";
   private static final String AUTHOR_2 = "kakm@google.com";
@@ -84,10 +80,10 @@ public final class AnnouncementsServletTest {
     this.datastore = DatastoreServiceFactory.getDatastoreService();
 
     announcement1 = new Entity(ANNOUNCEMENT_PROP);
-    announcement1.setProperty(AUTHOR_PROP, AUTHOR_1);
-    announcement1.setProperty(CLUB_PROP, CLUB_1);
-    announcement1.setProperty(CONTENT_PROP, CONTENT_1);
-    announcement1.setProperty(TIME_PROP, TIME_10);
+    announcement1.setProperty(Constants.AUTHOR_PROP, AUTHOR_1);
+    announcement1.setProperty(Constants.CLUB_PROP, CLUB_1);
+    announcement1.setProperty(Constants.CONTENT_PROP, CONTENT_1);
+    announcement1.setProperty(Constants.TIME_PROP, TIME_10);
 
     this.datastore.put(announcement1);
   }
@@ -119,10 +115,11 @@ public final class AnnouncementsServletTest {
     Assert.assertEquals(expectedSize, response.size());
 
     JsonObject announcement = response.get(0).getAsJsonObject();
-    Assert.assertEquals(AUTHOR_1, announcement.get(AUTHOR_PROP).getAsString());
-    Assert.assertEquals(CLUB_1, announcement.get(CLUB_PROP).getAsString());
-    Assert.assertEquals(CONTENT_1, announcement.get(CONTENT_PROP).getAsString());
-    Assert.assertEquals(TIME_10, announcement.get(TIME_PROP).getAsLong());
+    System.out.println(announcement);
+    Assert.assertEquals(AUTHOR_1, announcement.get(Constants.AUTHOR_PROP).getAsString());
+    Assert.assertEquals(CLUB_1, announcement.get(Constants.CLUB_PROP).getAsString());
+    Assert.assertEquals(CONTENT_1, announcement.get(Constants.CONTENT_PROP).getAsString());
+    Assert.assertEquals(TIME_10, announcement.get(Constants.TIME_PROP).getAsLong());
   }
 
   private JsonArray getServletResponse(AnnouncementsServlet servlet) throws IOException {

--- a/capstone/src/test/java/com/google/sps/servlets/announcements/AnnouncementsServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/announcements/AnnouncementsServletTest.java
@@ -115,7 +115,6 @@ public final class AnnouncementsServletTest {
     Assert.assertEquals(expectedSize, response.size());
 
     JsonObject announcement = response.get(0).getAsJsonObject();
-    System.out.println(announcement);
     Assert.assertEquals(AUTHOR_1, announcement.get(Constants.AUTHOR_PROP).getAsString());
     Assert.assertEquals(CLUB_1, announcement.get(Constants.CLUB_PROP).getAsString());
     Assert.assertEquals(CONTENT_1, announcement.get(Constants.CONTENT_PROP).getAsString());


### PR DESCRIPTION
This PR resolves some issues we're having with shared constants. The CLUB_PROP constant has had conflated usage between "club", the property in an Announcement object, and "Club", the entity descriptor for Datastore. This PR separates this constant into CLUB_PROP = "club", for usage as a property of objects, and CLUB_ENTITY_PROP = "Club", for usage as a descriptor for Datastore. 