### PR TITLE
Allow the author of an announcement to edit it. 

### DIFF
--- a/capstone/src/main/java/com/google/sps/servlets/announcements/EditAnnouncementServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/EditAnnouncementServlet.java
@@ -35,17 +35,7 @@ public class EditAnnouncementServlet extends HttpServlet {
 
     Query query = new Query(Constants.ANNOUNCEMENT_PROP);
     PreparedQuery results = datastore.prepare(query);
-
-    ImmutableList<Entity> entities =
-        Streams.stream(results.asIterable())
-            .filter(
-                entity ->
-                    club.equals(entity.getProperty(Constants.CLUB_PROP))
-                        && id.equals(
-                            entity.getProperty(Constants.AUTHOR_PROP).toString()
-                                + entity.getProperty(Constants.CONTENT_PROP).toString()
-                                + entity.getProperty(Constants.TIME_PROP).toString()))
-            .collect(toImmutableList());
+    ImmutableList<Entity> entities = doPostHelper(results, club, id);
 
     if (entities.isEmpty()) {
       return; // No such announcement matches parameters.

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/EditAnnouncementServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/EditAnnouncementServlet.java
@@ -48,6 +48,10 @@ public class EditAnnouncementServlet extends HttpServlet {
             .collect(toImmutableList());
 
     Entity entity = entities.get(0);
+    if (!entity.getProperty(Constants.AUTHOR_PROP).equals(userEmail)) {
+      return; //Not authorized to edit this announcement!
+    }
+
     entity.setProperty(Constants.CONTENT_PROP, content);
     datastore.put(entity);
 

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/EditAnnouncementServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/EditAnnouncementServlet.java
@@ -1,0 +1,56 @@
+package com.google.sps.servlets;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet that returns some example club content */
+@WebServlet("/edit-announcement")
+public class EditAnnouncementServlet extends HttpServlet {
+
+  private final String ID_PROP = "id";
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
+    String userEmail = userService.getCurrentUser().getEmail();
+    String id = request.getParameter(ID_PROP);
+    String content = request.getParameter(Constants.CONTENT_PROP);
+    String club = request.getParameter(Constants.CLUB_PROP);
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+    Query query = new Query(Constants.ANNOUNCEMENT_PROP);
+    PreparedQuery results = datastore.prepare(query);
+
+    ImmutableList<Entity> entities =
+        Streams.stream(results.asIterable())
+            .filter(
+                entity ->
+                    club.equals(entity.getProperty(Constants.CLUB_PROP))
+                        && id.equals(
+                            entity.getProperty(Constants.AUTHOR_PROP).toString()
+                                + entity.getProperty(Constants.CONTENT_PROP).toString()
+                                + entity.getProperty(Constants.TIME_PROP).toString()))
+            .collect(toImmutableList());
+
+    Entity entity = entities.get(0);
+    entity.setProperty(Constants.CONTENT_PROP, content);
+    datastore.put(entity);
+
+    response.sendRedirect("/about-us.html?name=" + club + "&tab=announcements");
+  }
+}

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/EditAnnouncementServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/EditAnnouncementServlet.java
@@ -47,14 +47,31 @@ public class EditAnnouncementServlet extends HttpServlet {
                                 + entity.getProperty(Constants.TIME_PROP).toString()))
             .collect(toImmutableList());
 
+    if (entities.isEmpty()) {
+      return; // No such announcement matches parameters.
+    }
     Entity entity = entities.get(0);
     if (!entity.getProperty(Constants.AUTHOR_PROP).equals(userEmail)) {
-      return; //Not authorized to edit this announcement!
+      return; // Not authorized to edit this announcement!
     }
 
     entity.setProperty(Constants.CONTENT_PROP, content);
     datastore.put(entity);
 
     response.sendRedirect("/about-us.html?name=" + club + "&tab=announcements");
+  }
+
+  ImmutableList<Entity> doPostHelper(PreparedQuery results, String clubName, String id) {
+    ImmutableList<Entity> entities =
+        Streams.stream(results.asIterable())
+            .filter(
+                entity ->
+                    clubName.equals(entity.getProperty(Constants.CLUB_PROP))
+                        && id.equals(
+                            entity.getProperty(Constants.AUTHOR_PROP).toString()
+                                + entity.getProperty(Constants.CONTENT_PROP).toString()
+                                + entity.getProperty(Constants.TIME_PROP).toString()))
+            .collect(toImmutableList());
+    return entities;
   }
 }

--- a/capstone/src/main/webapp/about-us.html
+++ b/capstone/src/main/webapp/about-us.html
@@ -64,7 +64,7 @@
                   <input type="hidden" id="author" name="author">
                   <input type="hidden" id="time" name="time">
                   <input type="hidden" id="content" name="content">
-                  <button type="submit" class="delete-announcement fa fa-trash-o" style="font-size:24px" style="display:none"></button>
+                  <button type="submit" class="delete-announcement fa fa-trash-o" style="font-size:24px"></button>
                 </form>
                 <button class="fa fa-edit edit-announcement" style="display:none;"></button>
                 <form action="/edit-announcement" class="change-form" method="POST">
@@ -72,8 +72,7 @@
                   <input type="hidden" class="announcement-id" name="id">
                   <input type="hidden" class="announcement-new-content" name="content">
                 </form>
-                <button class="save-announcement" style="display:none;">Save</button>
-                
+                <button class="save-announcement">Save</button>
               </div>
             </div>
           </template>

--- a/capstone/src/main/webapp/about-us.html
+++ b/capstone/src/main/webapp/about-us.html
@@ -67,6 +67,11 @@
                   <button type="submit" class="delete-announcement fa fa-trash-o" style="font-size:24px" style="display:none"></button>
                 </form>
                 <button class="fa fa-edit edit-announcement" style="display:none;"></button>
+                <form action="/edit-announcement" class="change-form" method="POST">
+                  <input type="hidden" class="club" name="club">
+                  <input type="hidden" class="announcement-id" name="id">
+                  <input type="hidden" class="announcement-new-content" name="content">
+                </form>
                 <button class="save-announcement" style="display:none;">Save</button>
                 
               </div>

--- a/capstone/src/main/webapp/about-us.html
+++ b/capstone/src/main/webapp/about-us.html
@@ -54,11 +54,11 @@
             <div id="announcement-container">
               <img id="announcement-profile-picture">
               <div id="announcement-body">
-                <b id="announcement-author"></b>:
-                <p id="announcement-content"></p>
+                <b class="announcement-author"></b>:
+                <p class="announcement-content"></p>
               </div>
               <div id="announcement-right">
-                <p id="announcement-time"></p>
+                <p class="announcement-time"></p>
                 <form action="/delete-announcement" method="POST">
                   <input type="hidden" id="club" name="club">
                   <input type="hidden" id="author" name="author">
@@ -66,6 +66,9 @@
                   <input type="hidden" id="content" name="content">
                   <button type="submit" class="delete-announcement fa fa-trash-o" style="font-size:24px" style="display:none"></button>
                 </form>
+                <button class="fa fa-edit edit-announcement" style="display:none;"></button>
+                <button class="save-announcement" style="display:none;">Save</button>
+                
               </div>
             </div>
           </template>

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -77,32 +77,61 @@ async function loadAnnouncements () {
   const color1 = "#AAA";
   const color2 = "#BBB";
   var evenOdd = true;
-  for (var announcement in json) {
-    template.content.querySelector('img').src = 'images/logo.png';
-    template.content.querySelector('#announcement-author').innerHTML = json[announcement].authorName;
-    template.content.querySelector('#announcement-content').innerHTML = json[announcement].content;
+  for (var announcement of json) {
+    const id = announcement.author + announcement.content + announcement.time; //Unique string to identiy this announcement.
 
-    const dateString = new Date(json[announcement].time).toLocaleDateString("en-US");
-    const timeString = new Date(json[announcement].time).toLocaleTimeString("en-US");
-    template.content.querySelector('#announcement-time').innerHTML = timeString + " on " + dateString;
+    template.content.querySelector('img').src = 'images/logo.png';
+    template.content.querySelector('.announcement-author').innerHTML = announcement.authorName;
+    template.content.querySelector('.announcement-content').innerHTML = announcement.content;
+    template.content.querySelector('.announcement-content').id = id;
+    
+
+    const dateString = new Date(announcement.time).toLocaleDateString("en-US");
+    const timeString = new Date(announcement.time).toLocaleTimeString("en-US");
+    template.content.querySelector('.announcement-time').innerHTML = timeString + " on " + dateString;
 
     backgroundColor = evenOdd ? color1 : color2; //In order to switch background colors every announcement
     template.content.querySelector('#announcement-container').style.backgroundColor = backgroundColor;
     evenOdd = !evenOdd;
 
-    if (JSON.parse(json[announcement].isAuthor)) {
+    if (JSON.parse(announcement.isAuthor)) {
       template.content.querySelector('.delete-announcement').style = "display: inline-block;";
-      template.content.querySelector('#club').value = json[announcement].club;
-      template.content.querySelector('#author').value = json[announcement].author;
-      template.content.querySelector('#content').value = json[announcement].content;
-      template.content.querySelector('#time').value = json[announcement].time;
+      template.content.querySelector('.edit-announcement').style = "display: inline-block;";
+      template.content.querySelector('.edit-announcement').id = id + '-edit';
+      template.content.querySelector('.save-announcement').id = id + '-save';
+
+      template.content.querySelector('#club').value = announcement.club;
+      template.content.querySelector('#author').value = announcement.author;
+      template.content.querySelector('#content').value = announcement.content;
+      template.content.querySelector('#time').value = announcement.time;
     } else {
       template.content.querySelector('.delete-announcement').style = "display: none;";
+      template.content.querySelector('.edit-announcement').style = "display: none;";
     }
 
     var clone = document.importNode(template.content, true);
     document.getElementById('announcements-display').appendChild(clone);
+
+    if (JSON.parse(announcement.isAuthor)) {
+      document.getElementById(id + '-edit').onclick = function () {
+        allowEditAnnouncement(id);
+      };
+      document.getElementById(id + '-save').onclick = function () {
+        saveAnnouncement(id);
+      };
+    }
+
   }
+}
+
+function allowEditAnnouncement (id) {
+  document.getElementById(id).contentEditable = 'true';
+  document.getElementById(id + '-edit').style = 'display: none;';
+  document.getElementById(id + '-save').style = 'display: inline-block;';
+}
+
+function saveAnnouncement (id) {
+    console.log("Saving announcement " + id);
 }
 
 /** Displays a certain tab for a club, by first checking for a GET parameter 

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -95,8 +95,8 @@ async function loadAnnouncements () {
     evenOdd = !evenOdd;
 
     if (JSON.parse(announcement.isAuthor)) {
-      template.content.querySelector('.delete-announcement').style = "display: inline-block;";
-      template.content.querySelector('.edit-announcement').style = "display: inline-block;";
+      template.content.querySelector('.delete-announcement').style.display = 'inline-block';
+      template.content.querySelector('.edit-announcement').style.display = 'inline-block';
       template.content.querySelector('.edit-announcement').id = id + '-edit';
       template.content.querySelector('.save-announcement').id = id + '-save';
       template.content.querySelector('.announcement-new-content').id = id + '-new';
@@ -132,7 +132,7 @@ async function loadAnnouncements () {
 function allowEditAnnouncement (id) {
   document.getElementById(id).contentEditable = 'true';
   document.getElementById(id + '-edit').style = 'display: none;';
-  document.getElementById(id + '-save').style = 'display: inline-block;';
+  document.getElementById(id + '-save').style.display = 'inline-block';
 }
 
 function saveAnnouncement (id) {

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -99,6 +99,11 @@ async function loadAnnouncements () {
       template.content.querySelector('.edit-announcement').style = "display: inline-block;";
       template.content.querySelector('.edit-announcement').id = id + '-edit';
       template.content.querySelector('.save-announcement').id = id + '-save';
+      template.content.querySelector('.announcement-new-content').id = id + '-new';
+      template.content.querySelector('.announcement-id').value = id;
+      template.content.querySelector('.club').value = announcement.club;
+      template.content.querySelector('.change-form').id = id + '-form';
+      
 
       template.content.querySelector('#club').value = announcement.club;
       template.content.querySelector('#author').value = announcement.author;
@@ -131,7 +136,10 @@ function allowEditAnnouncement (id) {
 }
 
 function saveAnnouncement (id) {
-    console.log("Saving announcement " + id);
+  const newContent = document.getElementById(id).innerHTML;
+  document.getElementById(id + '-new').value = newContent;
+  document.getElementById(id + '-form').submit();
+
 }
 
 /** Displays a certain tab for a club, by first checking for a GET parameter 

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -78,7 +78,7 @@ async function loadAnnouncements () {
   const color2 = "#BBB";
   var evenOdd = true;
   for (var announcement of json) {
-    const id = announcement.author + announcement.content + announcement.time; //Unique string to identiy this announcement.
+    const id = announcement.author + announcement.content + announcement.time; // Unique string to identiy this announcement.
 
     template.content.querySelector('img').src = 'images/logo.png';
     template.content.querySelector('.announcement-author').innerHTML = announcement.authorName;
@@ -90,7 +90,7 @@ async function loadAnnouncements () {
     const timeString = new Date(announcement.time).toLocaleTimeString("en-US");
     template.content.querySelector('.announcement-time').innerHTML = timeString + " on " + dateString;
 
-    backgroundColor = evenOdd ? color1 : color2; //In order to switch background colors every announcement
+    backgroundColor = evenOdd ? color1 : color2; // In order to switch background colors every announcement
     template.content.querySelector('#announcement-container').style.backgroundColor = backgroundColor;
     evenOdd = !evenOdd;
 

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -78,7 +78,6 @@ async function loadAnnouncements () {
   const color2 = "#BBB";
   var evenOdd = true;
   for (var announcement in json) {
-    console.log(json[announcement]);
     template.content.querySelector('img').src = 'images/logo.png';
     template.content.querySelector('#announcement-author').innerHTML = json[announcement].authorName;
     template.content.querySelector('#announcement-content').innerHTML = json[announcement].content;
@@ -91,8 +90,6 @@ async function loadAnnouncements () {
     template.content.querySelector('#announcement-container').style.backgroundColor = backgroundColor;
     evenOdd = !evenOdd;
 
-    console.log(json[announcement].isAuthor);
-    console.log(JSON.parse(json[announcement].isAuthor));
     if (JSON.parse(json[announcement].isAuthor)) {
       template.content.querySelector('.delete-announcement').style = "display: inline-block;";
       template.content.querySelector('#club').value = json[announcement].club;

--- a/capstone/src/main/webapp/style.css
+++ b/capstone/src/main/webapp/style.css
@@ -250,3 +250,8 @@ button {
 #announcement-time {
     display:inline-block;
 }
+
+.save-announcement,
+.delete-announcement {
+    display: none;
+}

--- a/capstone/src/test/java/com/google/sps/servlets/announcements/EditAnnouncementServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/announcements/EditAnnouncementServletTest.java
@@ -1,0 +1,154 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.mockito.Mockito.when;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.tools.development.testing.LocalBlobstoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** */
+@RunWith(JUnit4.class)
+public final class EditAnnouncementServletTest {
+
+  private final long SAMPLE_TIME = 123456789;
+  private final String SAMPLE_CLUB_NAME = "Test Club";
+  private final String SAMPLE_CONTENT = "A random announcement";
+  private final String SAMPLE_NEW_CONTENT = "A new announcement";
+  private final String TEST_EMAIL = "test-email@gmail.com";
+  private final String ID_PROP = "id";
+
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  private DatastoreService datastore;
+  private EditAnnouncementServlet servlet;
+
+  private LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+          new LocalDatastoreServiceTestConfig().setDefaultHighRepJobPolicyUnappliedJobPercentage(0),
+          new LocalUserServiceTestConfig(),
+          new LocalBlobstoreServiceTestConfig());
+
+  @Before
+  public void setUp() throws IOException {
+    helper.setUp();
+    MockitoAnnotations.initMocks(this);
+    this.servlet = new EditAnnouncementServlet();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void doPost_authorizedEdit() throws ServletException, IOException {
+    prepare();
+    helper.setEnvEmail(TEST_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
+
+    String id = TEST_EMAIL + SAMPLE_CONTENT + SAMPLE_TIME;
+    when(request.getParameter(Constants.CONTENT_PROP)).thenReturn(SAMPLE_NEW_CONTENT);
+    when(request.getParameter(Constants.CLUB_PROP)).thenReturn(SAMPLE_CLUB_NAME);
+    when(request.getParameter(ID_PROP)).thenReturn(id);
+    servlet.doPost(request, response);
+
+    Query query = new Query(Constants.ANNOUNCEMENT_PROP);
+    PreparedQuery results = datastore.prepare(query);
+
+    String newId = TEST_EMAIL + SAMPLE_NEW_CONTENT + SAMPLE_TIME;
+    ImmutableList<Entity> entities =
+        Streams.stream(results.asIterable())
+            .filter(
+                entity ->
+                    SAMPLE_CLUB_NAME.equals(entity.getProperty(Constants.CLUB_PROP))
+                        && newId.equals(
+                            entity.getProperty(Constants.AUTHOR_PROP).toString()
+                                + entity.getProperty(Constants.CONTENT_PROP).toString()
+                                + entity.getProperty(Constants.TIME_PROP).toString()))
+            .collect(toImmutableList());
+
+    Entity entity = entities.get(0);
+
+    Assert.assertNotNull(entity);
+    Assert.assertEquals(SAMPLE_NEW_CONTENT, entity.getProperty(Constants.CONTENT_PROP));
+  }
+
+  @Test
+  public void doPost_unauthorizedEdit() throws ServletException, IOException {
+    prepare();
+    helper
+        .setEnvEmail("anotherEmail@google.com")
+        .setEnvAuthDomain("google.com")
+        .setEnvIsLoggedIn(true);
+
+    String id = TEST_EMAIL + SAMPLE_CONTENT + SAMPLE_TIME;
+    when(request.getParameter(Constants.CONTENT_PROP)).thenReturn(SAMPLE_NEW_CONTENT);
+    when(request.getParameter(Constants.CLUB_PROP)).thenReturn(SAMPLE_CLUB_NAME);
+    when(request.getParameter(ID_PROP)).thenReturn(id);
+    servlet.doPost(request, response);
+
+    Query query = new Query(Constants.ANNOUNCEMENT_PROP);
+    PreparedQuery results = datastore.prepare(query);
+
+    ImmutableList<Entity> entities =
+        Streams.stream(results.asIterable())
+            .filter(
+                entity ->
+                    SAMPLE_CLUB_NAME.equals(entity.getProperty(Constants.CLUB_PROP))
+                        && id.equals(
+                            entity.getProperty(Constants.AUTHOR_PROP).toString()
+                                + entity.getProperty(Constants.CONTENT_PROP).toString()
+                                + entity.getProperty(Constants.TIME_PROP).toString()))
+            .collect(toImmutableList());
+
+    Entity entity = entities.get(0);
+
+    Assert.assertNotNull(entity);
+    Assert.assertEquals(SAMPLE_CONTENT, entity.getProperty(Constants.CONTENT_PROP));
+  }
+
+  private void prepare() {
+    Entity announcementEntity = new Entity(Constants.ANNOUNCEMENT_PROP);
+    announcementEntity.setProperty(Constants.AUTHOR_PROP, TEST_EMAIL);
+    announcementEntity.setProperty(Constants.TIME_PROP, SAMPLE_TIME);
+    announcementEntity.setProperty(Constants.CONTENT_PROP, SAMPLE_CONTENT);
+    announcementEntity.setProperty(Constants.CLUB_PROP, SAMPLE_CLUB_NAME);
+
+    datastore.put(announcementEntity);
+  }
+}


### PR DESCRIPTION
This PR implements the front-end and back-end for allowing the author (and only the author, as suggested by front-end and verified by back-end) to edit any given announcement by simply clicking on the pencil button and writing. The edited announcement gets put into datastore, and the page reloaded. 