### PR TITLE
Add "edited" flag to each announcement

### DIFF
--- a/capstone/src/main/java/com/google/sps/servlets/Announcement.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Announcement.java
@@ -7,14 +7,22 @@ public class Announcement {
   private String content;
   private boolean isAuthor;
   private String authorName;
+  private boolean edited;
 
   public Announcement(
-      String author, String club, long time, String content, boolean isAuthor, String authorName) {
+      String author,
+      String club,
+      long time,
+      String content,
+      boolean isAuthor,
+      String authorName,
+      boolean edited) {
     this.author = author;
     this.club = club;
     this.time = time;
     this.content = content;
     this.isAuthor = isAuthor;
     this.authorName = authorName;
+    this.edited = edited;
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -20,6 +20,7 @@ class Constants {
   static final String ANNOUNCEMENT_PROP = "Announcement";
   static final String AUTHOR_PROP = "author";
   static final String TIME_PROP = "time";
+  static final String EDITED_PROP = "edited";
   static final String CONTENT_PROP = "content";
   static final String JOIN_CLUB_PROP = "join";
   static final String BLOB_KEY_PROP = "blobKey";

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
@@ -51,7 +51,8 @@ public class AnnouncementsServlet extends HttpServlet {
                         entity.getProperty(Constants.CONTENT_PROP).toString(),
                         userEmail.equals(entity.getProperty(Constants.AUTHOR_PROP).toString()),
                         Student.getNameByEmail(
-                            entity.getProperty(Constants.AUTHOR_PROP).toString())))
+                            entity.getProperty(Constants.AUTHOR_PROP).toString()),
+                        Boolean.parseBoolean(entity.getProperty(Constants.EDITED_PROP).toString())))
             .collect(toImmutableList());
 
     Gson gson = new Gson();
@@ -80,6 +81,7 @@ public class AnnouncementsServlet extends HttpServlet {
     announcementEntity.setProperty(Constants.TIME_PROP, System.currentTimeMillis());
     announcementEntity.setProperty(Constants.CONTENT_PROP, announcementContent);
     announcementEntity.setProperty(Constants.CLUB_PROP, clubName);
+    announcementEntity.setProperty(Constants.EDITED_PROP, false);
 
     datastore.put(announcementEntity);
 

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/EditAnnouncementServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/EditAnnouncementServlet.java
@@ -46,6 +46,7 @@ public class EditAnnouncementServlet extends HttpServlet {
     }
 
     entity.setProperty(Constants.CONTENT_PROP, content);
+    entity.setProperty(Constants.EDITED_PROP, true);
     datastore.put(entity);
 
     response.sendRedirect("/about-us.html?name=" + club + "&tab=announcements");

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -78,8 +78,9 @@ async function loadAnnouncements () {
   const template = document.querySelector('#announcement-element');
 
   var backgroundColor;
-  const color1 = "#AAA";
-  const color2 = "#BBB";
+  const color1 = '#AAA';
+  const color2 = '#BBB';
+  const editedFlag = ' (edited)';
   var evenOdd = true;
   for (var announcement of json) {
     const id = announcement.author + announcement.content + announcement.time; // Unique string to identiy this announcement.
@@ -87,6 +88,9 @@ async function loadAnnouncements () {
     template.content.querySelector('img').src = 'images/profile.jpeg';
     template.content.querySelector('.announcement-author').innerHTML = announcement.authorName;
     template.content.querySelector('.announcement-content').innerHTML = announcement.content;
+    if (JSON.parse(announcement.edited)) {
+        template.content.querySelector('.announcement-author').innerHTML += editedFlag;
+    }
     template.content.querySelector('.announcement-content').id = id;
 
     const dateString = new Date(announcement.time).toLocaleDateString("en-US");
@@ -107,7 +111,6 @@ async function loadAnnouncements () {
       template.content.querySelector('.club').value = announcement.club;
       template.content.querySelector('.change-form').id = id + '-form';
       
-
       template.content.querySelector('#club').value = announcement.club;
       template.content.querySelector('#author').value = announcement.author;
       template.content.querySelector('#content').value = announcement.content;

--- a/capstone/src/test/java/com/google/sps/servlets/announcements/AnnouncementsServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/announcements/AnnouncementsServletTest.java
@@ -84,6 +84,7 @@ public final class AnnouncementsServletTest {
     announcement1.setProperty(Constants.CLUB_PROP, CLUB_1);
     announcement1.setProperty(Constants.CONTENT_PROP, CONTENT_1);
     announcement1.setProperty(Constants.TIME_PROP, TIME_10);
+    announcement1.setProperty(Constants.EDITED_PROP, false);
 
     this.datastore.put(announcement1);
   }
@@ -119,6 +120,7 @@ public final class AnnouncementsServletTest {
     Assert.assertEquals(CLUB_1, announcement.get(Constants.CLUB_PROP).getAsString());
     Assert.assertEquals(CONTENT_1, announcement.get(Constants.CONTENT_PROP).getAsString());
     Assert.assertEquals(TIME_10, announcement.get(Constants.TIME_PROP).getAsLong());
+    Assert.assertFalse(announcement.get(Constants.EDITED_PROP).getAsBoolean());
   }
 
   private JsonArray getServletResponse(AnnouncementsServlet servlet) throws IOException {

--- a/capstone/src/test/java/com/google/sps/servlets/announcements/EditAnnouncementServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/announcements/EditAnnouncementServletTest.java
@@ -96,6 +96,7 @@ public final class EditAnnouncementServletTest {
 
     Assert.assertNotNull(entity);
     Assert.assertEquals(SAMPLE_NEW_CONTENT, entity.getProperty(Constants.CONTENT_PROP));
+    Assert.assertEquals(true, entity.getProperty(Constants.EDITED_PROP));
   }
 
   @Test
@@ -121,6 +122,7 @@ public final class EditAnnouncementServletTest {
 
     Assert.assertNotNull(entity);
     Assert.assertEquals(SAMPLE_CONTENT, entity.getProperty(Constants.CONTENT_PROP));
+    Assert.assertEquals(false, entity.getProperty(Constants.EDITED_PROP));
   }
 
   private void prepare() {
@@ -129,7 +131,7 @@ public final class EditAnnouncementServletTest {
     announcementEntity.setProperty(Constants.TIME_PROP, SAMPLE_TIME);
     announcementEntity.setProperty(Constants.CONTENT_PROP, SAMPLE_CONTENT);
     announcementEntity.setProperty(Constants.CLUB_PROP, SAMPLE_CLUB_NAME);
-
+    announcementEntity.setProperty(Constants.EDITED_PROP, false);
     datastore.put(announcementEntity);
   }
 }


### PR DESCRIPTION
This PR adds the feature that once an announcement gets edited, it will show up with a flag marking as such (kind of like how YouTube will mark comments as having been edited, i.e. "Kevin Shao commented (edited): ..."). This required a minor change in the announcement object itself, as well as all the servlets that are related. Each announcement object is initialized with an "edited" boolean to false, and set to true when EditAnnouncementServlet's doPost is called. 