### PR TITLE
Provide basic options to sort the explore page

### DIFF
--- a/capstone/src/main/java/com/google/sps/servlets/Club.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Club.java
@@ -29,4 +29,12 @@ public class Club {
   public boolean hasOfficer(String officer) {
     return officers.contains(officer);
   }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getSize() {
+    return members.size();
+  }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/Club.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Club.java
@@ -10,6 +10,7 @@ public class Club {
   private String description;
   private String website;
   private String logo;
+  private long time;
 
   public Club(
       String name,
@@ -17,13 +18,15 @@ public class Club {
       ImmutableList<String> officers,
       String description,
       String website,
-      String logo) {
+      String logo,
+      long creationTime) {
     this.name = name;
     this.members = members;
     this.officers = officers;
     this.description = description;
     this.website = website;
     this.logo = logo;
+    this.time = creationTime;
   }
 
   public boolean hasOfficer(String officer) {
@@ -36,5 +39,9 @@ public class Club {
 
   public int getSize() {
     return members.size();
+  }
+
+  public long getCreationTime() {
+    return time;
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -12,6 +12,10 @@ class Constants {
   static final String PROPERTY_CLUBS = "clubs";
   static final String DESCRIP_PROP = "description";
   static final String WEBSITE_PROP = "website";
+  static final String SORT_PROP = "sort";
+  static final String DEFAULT_SORT_PROP = "default";
+  static final String ALPHA_SORT_PROP = "alpha";
+  static final String SIZE_SORT_PROP = "size";
   static final String LOGO_PROP = "logo";
   static final String MEMBER_PROP = "members";
   static final String OFFICER_PROP = "officers";

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -54,17 +54,18 @@ public class ExploreServlet extends HttpServlet {
         ServletUtil.getPropertyList(entity, Constants.OFFICER_PROP),
         entity.getProperty(Constants.DESCRIP_PROP).toString(),
         entity.getProperty(Constants.WEBSITE_PROP).toString(),
-        key);
+        key,
+        Long.parseLong(entity.getProperty(Constants.TIME_PROP).toString()));
   }
 
   private Comparator<Club> getComparator(String sort) {
     if (sort.equals(Constants.ALPHA_SORT_PROP)) {
-      return Comparator.comparing(club -> club.getName().toLowerCase()); //Should be case-insensitive
+      return Comparator.comparing(
+          club -> club.getName().toLowerCase()); // Should be case-insensitive
     } else if (sort.equals(Constants.SIZE_SORT_PROP)) {
       return Collections.reverseOrder(Comparator.comparing(club -> club.getSize()));
     } else {
-      return Comparator.comparing(club -> club.getName().toLowerCase()); // TODO should switch to date of creation
+      return Comparator.comparing(club -> club.getCreationTime());
     }
   }
-
 }

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -11,6 +11,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import com.google.gson.Gson;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -24,12 +26,16 @@ public class ExploreServlet extends HttpServlet {
     Gson gson = new Gson();
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
+    String sort = request.getParameter(Constants.SORT_PROP);
+    Comparator<Club> comparator = getComparator(sort);
+
     Query query = new Query(Constants.CLUB_ENTITY_PROP);
     PreparedQuery results = datastore.prepare(query);
     ImmutableList<Club> clubs =
         Streams.stream(results.asIterable())
-            .limit(Constants.LOAD_LIMIT)
             .map(entity -> createClubFromEntity(entity))
+            .sorted(comparator)
+            .limit(Constants.LOAD_LIMIT)
             .collect(toImmutableList());
 
     String json = gson.toJson(clubs);
@@ -50,4 +56,15 @@ public class ExploreServlet extends HttpServlet {
         entity.getProperty(Constants.WEBSITE_PROP).toString(),
         key);
   }
+
+  private Comparator<Club> getComparator(String sort) {
+    if (sort.equals(Constants.ALPHA_SORT_PROP)) {
+      return Comparator.comparing(club -> club.getName().toLowerCase()); //Should be case-insensitive
+    } else if (sort.equals(Constants.SIZE_SORT_PROP)) {
+      return Collections.reverseOrder(Comparator.comparing(club -> club.getSize()));
+    } else {
+      return Comparator.comparing(club -> club.getName().toLowerCase()); // TODO should switch to date of creation
+    }
+  }
+
 }

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -59,13 +59,14 @@ public class ExploreServlet extends HttpServlet {
   }
 
   private Comparator<Club> getComparator(String sort) {
-    if (sort.equals(Constants.ALPHA_SORT_PROP)) {
-      return Comparator.comparing(
-          club -> club.getName().toLowerCase()); // Should be case-insensitive
-    } else if (sort.equals(Constants.SIZE_SORT_PROP)) {
-      return Collections.reverseOrder(Comparator.comparing(club -> club.getSize()));
-    } else {
-      return Comparator.comparing(club -> club.getCreationTime());
+    switch (sort) {
+      case Constants.ALPHA_SORT_PROP:
+        return Comparator.comparing(
+            club -> club.getName().toLowerCase()); // Should be case-insensitive    
+      case Constants.SIZE_SORT_PROP:
+        return Collections.reverseOrder(Comparator.comparing(club -> club.getSize()));
+      default: 
+        return Comparator.comparing(club -> club.getCreationTime());
     }
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
@@ -106,6 +106,7 @@ public class AnnouncementsServlet extends HttpServlet {
         ImmutableList.copyOf((ArrayList<String>) entity.getProperty(Constants.OFFICER_PROP)),
         entity.getProperty(Constants.DESCRIP_PROP).toString(),
         entity.getProperty(Constants.WEBSITE_PROP).toString(),
-        key);
+        key,
+        Long.parseLong(entity.getProperty(Constants.TIME_PROP).toString()));
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -48,7 +48,8 @@ public class ClubServlet extends HttpServlet {
         logoKey = clubEntity.getProperty(Constants.LOGO_PROP).toString();
       }
       boolean isOfficer = officers.contains(userEmail);
-      Club club = new Club(name, members, officers, description, website, logoKey);
+      long creationTime = Long.parseLong(clubEntity.getProperty(Constants.TIME_PROP).toString());
+      Club club = new Club(name, members, officers, description, website, logoKey, creationTime);
       Gson gson = new Gson();
       JsonElement jsonElement = gson.toJsonTree(club);
       jsonElement.getAsJsonObject().addProperty("isOfficer", isOfficer);
@@ -104,6 +105,7 @@ public class ClubServlet extends HttpServlet {
       clubEntity.setProperty(Constants.MEMBER_PROP, ImmutableList.of(founderEmail));
       clubEntity.setProperty(Constants.OFFICER_PROP, ImmutableList.of(founderEmail));
       clubEntity.setProperty(Constants.LOGO_PROP, blobKey);
+      clubEntity.setProperty(Constants.TIME_PROP, System.currentTimeMillis());
       datastore.put(clubEntity);
 
       addClubToFoundersClubList(datastore, founderEmail, clubName);

--- a/capstone/src/main/webapp/explore-loader.js
+++ b/capstone/src/main/webapp/explore-loader.js
@@ -1,13 +1,15 @@
-getListings();
 
 async function getListings () {
-  const query = '/explore';
+  const sortType = document.getElementById('sort-type').value;
+
+  const query = '/explore?sort=' + sortType;
   const response = await fetch(query);
   const json = await response.json();
   loadListings(json);
 }
 
 async function loadListings (json) {
+  document.getElementById('club-listings').innerHTML = ''; //Clear the listings div, for if we're refreshing the listings
   const template = document.querySelector('#club-listing');
   for (var club of json) {
     imageUrl = 'images/logo.png';

--- a/capstone/src/main/webapp/explore-loader.js
+++ b/capstone/src/main/webapp/explore-loader.js
@@ -9,7 +9,7 @@ async function getListings () {
 }
 
 async function loadListings (json) {
-  document.getElementById('club-listings').innerHTML = ''; //Clear the listings div, for if we're refreshing the listings
+  document.getElementById('club-listings').innerHTML = ''; // Clear the listings div, for if we're refreshing the listings
   const template = document.querySelector('#club-listing');
   for (var club of json) {
     imageUrl = 'images/logo.png';

--- a/capstone/src/main/webapp/index.html
+++ b/capstone/src/main/webapp/index.html
@@ -7,23 +7,29 @@
     <script src="script.js"></script>
     <script src="explore-loader.js"></script>
   </head>
-  <body>
+  <body onload="getListings()">
     <div id="top-navigation"></div>
     <h1 id="explore-heading">Explore Clubs</h1>
     <div id="content">
-      <div id="club-listings" class="full-screen-panel">
-        <template id="club-listing">
-          <div class="club-logo-container">
-            <img src="" id="club-logo" class="club-logo" alt="Club logo">
-          </div>
-          <div class="club-info-container">
-            <h2><a href="" id="club-name"></a></h2>
-            <p id="description"></p>
-            <p id="members"></p>
-          </div> 
-          <form id="club-join-container" name="join" action="/student-data" method="POST"></form>
-        </template>
+      <div id="control-panel" class="full-screen-panel">
+        <select id="sort-type" onchange="getListings()">
+          <option value="default" selected>Default</option>
+          <option value="alpha">Alphabetical</option>
+          <option value="size">Size</option>
+        </select>
       </div>
+      <div id="club-listings" class="full-screen-panel"></div>
+      <template id="club-listing">
+        <div class="club-logo-container">
+          <img src="" id="club-logo" class="club-logo" alt="Club logo">
+        </div>
+        <div class="club-info-container">
+          <h2><a href="" id="club-name"></a></h2>
+          <p id="description"></p>
+          <p id="members"></p>
+        </div> 
+        <form id="club-join-container" name="join" action="/student-data" method="POST"></form>
+      </template>
       <button id="register-club-button" onclick="location.href='club-registration.html';">Register a new club!</button>
     </div>
   </body>

--- a/capstone/src/main/webapp/index.html
+++ b/capstone/src/main/webapp/index.html
@@ -13,7 +13,7 @@
     <div id="content">
       <div id="control-panel" class="full-screen-panel">
         <select id="sort-type" onchange="getListings()">
-          <option value="default" selected>Default</option>
+          <option value="default" selected>Chronological</option>
           <option value="alpha">Alphabetical</option>
           <option value="size">Size</option>
         </select>

--- a/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
@@ -95,6 +95,9 @@ public final class ExploreServletTest {
     String BLOB_KEY_1 = "fake blob key";
     String BLOB_KEY_2 = "another fake blob key";
 
+    long TIME_1 = 10;
+    long TIME_2 = 20;
+
     helper.setEnvEmail("kshao").setEnvAuthDomain("gmail.com").setEnvIsLoggedIn(true);
     when(request.getParameter(Constants.SORT_PROP)).thenReturn(Constants.DEFAULT_SORT_PROP);
 
@@ -105,6 +108,7 @@ public final class ExploreServletTest {
     club1.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_1);
     club1.setProperty(Constants.WEBSITE_PROP, SITE_1);
     club1.setProperty(Constants.LOGO_PROP, BLOB_KEY_1);
+    club1.setProperty(Constants.TIME_PROP, TIME_1);
 
     Entity club2 = new Entity(Constants.CLUB_ENTITY_PROP);
     club2.setProperty(Constants.PROPERTY_NAME, CLUB_2);
@@ -113,6 +117,7 @@ public final class ExploreServletTest {
     club2.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_2);
     club2.setProperty(Constants.WEBSITE_PROP, SITE_2);
     club2.setProperty(Constants.LOGO_PROP, BLOB_KEY_2);
+    club2.setProperty(Constants.TIME_PROP, TIME_2);
 
     this.datastore.put(club1);
     this.datastore.put(club2);
@@ -141,6 +146,7 @@ public final class ExploreServletTest {
     Assert.assertEquals(object0.get(Constants.DESCRIP_PROP).getAsString(), DESCRIPTION_1);
     Assert.assertEquals(object0.get(Constants.WEBSITE_PROP).getAsString(), SITE_1);
     Assert.assertEquals(object0.get(Constants.LOGO_PROP).getAsString(), BLOB_KEY_1);
+    Assert.assertEquals(object0.get(Constants.TIME_PROP).getAsLong(), TIME_1);
 
     JsonElement element1 = response.get(1);
     Assert.assertTrue(element1.isJsonObject());
@@ -161,6 +167,7 @@ public final class ExploreServletTest {
     Assert.assertEquals(object1.get(Constants.DESCRIP_PROP).getAsString(), DESCRIPTION_2);
     Assert.assertEquals(object1.get(Constants.WEBSITE_PROP).getAsString(), SITE_2);
     Assert.assertEquals(object1.get(Constants.LOGO_PROP).getAsString(), BLOB_KEY_2);
+    Assert.assertEquals(object1.get(Constants.TIME_PROP).getAsLong(), TIME_2);
   }
 
   private JsonArray getServletResponse(ExploreServlet servlet) throws IOException {

--- a/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
@@ -96,7 +96,7 @@ public final class ExploreServletTest {
     String BLOB_KEY_2 = "another fake blob key";
 
     helper.setEnvEmail("kshao").setEnvAuthDomain("gmail.com").setEnvIsLoggedIn(true);
-    when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn(CLUB_2);
+    when(request.getParameter(Constants.SORT_PROP)).thenReturn(Constants.DEFAULT_SORT_PROP);
 
     Entity club1 = new Entity(Constants.CLUB_ENTITY_PROP);
     club1.setProperty(Constants.PROPERTY_NAME, CLUB_1);

--- a/capstone/src/test/java/com/google/sps/servlets/clubs/ClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/clubs/ClubServletTest.java
@@ -46,6 +46,7 @@ public class ClubServletTest {
   private final String SAMPLE_CLUB_WEB = "www.test-club.com";
   private final String SAMPLE_BLOB = "test-blobkey";
   private final String TEST_EMAIL = "test-email@gmail.com";
+  private final long SAMPLE_TIME = 25;
   private final ImmutableList<String> STUDENT_LIST = ImmutableList.of(TEST_EMAIL);
 
   @Mock private HttpServletRequest request;
@@ -135,6 +136,7 @@ public class ClubServletTest {
     clubEntity.setProperty(Constants.OFFICER_PROP, expectedOfficers);
     clubEntity.setProperty(Constants.WEBSITE_PROP, "website.com");
     clubEntity.setProperty(Constants.LOGO_PROP, SAMPLE_BLOB);
+    clubEntity.setProperty(Constants.TIME_PROP, SAMPLE_TIME);
     datastore.put(clubEntity);
 
     StringWriter stringWriter = new StringWriter();
@@ -154,6 +156,7 @@ public class ClubServletTest {
     Assert.assertEquals(expectedMembers, actualMembers);
     Assert.assertEquals(expectedOfficers, actualOfficers);
     Assert.assertEquals("website.com", response.get(Constants.WEBSITE_PROP).getAsString());
+    Assert.assertEquals(SAMPLE_TIME, response.get(Constants.TIME_PROP).getAsLong());
   }
 
   @Test


### PR DESCRIPTION
This PR introduces a few basic options to sort the explore page: alphabetically, by size (number of members), and default (which is chronologically). The default method required an additional field in the Club object: time of creation. There's a select element on the explore page which, when changed, invokes the JS code to reload the club-listings section with the new (resorted) data. 