### PR TITLE
Use HTML for email templates

### DIFF
--- a/capstone/src/main/java/com/google/sps/gmail/EmailFactory.java
+++ b/capstone/src/main/java/com/google/sps/gmail/EmailFactory.java
@@ -31,8 +31,6 @@ public class EmailFactory {
   private static final String AUTH_USER = "me";
   private static final String SENDER_EMAIL =
       "kakm+clubhub@google.com"; // TODO: create dummy email to send email notifications from
-  private static final String EMAIL_PATH =
-      System.getProperty("user.home") + "/step179-2020/capstone/src/main/webapp/emailTemplates";
   private static Gmail service;
 
   public EmailFactory(Gmail service) {
@@ -77,19 +75,19 @@ public class EmailFactory {
 
     } catch (Exception e) {
       System.out.println("ERROR: Unable to send message : " + e.toString());
-      e.printStackTrace();
     }
   }
 
   private static String getHTMLAsString(String path) throws IOException {
-    String fullPath = EMAIL_PATH + path;
+    // Load HTML file and convert to String
+    String fullPath = Constants.EMAIL_PATH + path;
     File htmlTemplate = new File(fullPath);
     String emailBody = FileUtils.readFileToString(htmlTemplate, "utf-8");
     return emailBody;
   }
 
   public static void sendWelcomeEmail(String recipientEmail) throws IOException {
-    // Prepare email content and send email
+    // Prepare welcome email content and send
     String subject = String.format("Welcome to ClubHub!");
     String emailBody = getHTMLAsString("/welcome-email.html");
     sendEmail(recipientEmail, emailBody, subject);

--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -39,4 +39,6 @@ public final class Constants {
   public static final String PROFILE_PIC_PROP = "upload-profile";
   public static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
   public static final String APPLICATION_NAME = "clubhub-step-2020";
+  public static final String EMAIL_PATH =
+      System.getProperty("user.home") + "/step179-2020/capstone/src/main/webapp/emailTemplates";
 }

--- a/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
@@ -138,6 +138,7 @@ public class StudentServlet extends HttpServlet {
     if (students.isEmpty()) {
       Entity studentEntity = createStudentEntity(userEmail);
       datastore.put(studentEntity);
+      EmailFactory.sendWelcomeEmail(userEmail);
       results = datastore.prepare(query);
       students = ImmutableList.copyOf(results.asIterable());
     }

--- a/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
@@ -12,6 +12,7 @@ import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import com.google.gson.Gson;
+import com.google.sps.gmail.EmailFactory;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -128,7 +129,7 @@ public class StudentServlet extends HttpServlet {
     }
   }
 
-  private Entity getStudent(String userEmail, DatastoreService datastore) {
+  private Entity getStudent(String userEmail, DatastoreService datastore) throws IOException {
     // Get the user's information from Datastore
     Query query = new Query(userEmail);
     PreparedQuery results = datastore.prepare(query);

--- a/capstone/src/main/webapp/emailTemplates/announcement-email.html
+++ b/capstone/src/main/webapp/emailTemplates/announcement-email.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <script src="script.js"></script>
+    <style>
+      .email-content {
+        border: 2px double #000;
+        color: #000080;
+        font-size: 20px;
+        padding: 20px;
+        background: #f5fcfc;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="email-content">
+      <h2>Hi there!</h2>
+      <h3>You have a <b>new notification</b> from [CLUB_NAME].</h3>
+      <p>Announcement: [ANNOUNCEMENT]</p>
+      <p>To view this notification on ClubHub, visit the <a href="https://clubhub-step-2020.googleplex.com">ClubHub</a> 
+          platform and click "My Profile" at the top right corner.</p>
+      <p>Best Regards,<br>The ClubHub Team</p>
+    </div>
+  </body>
+</html>

--- a/capstone/src/main/webapp/emailTemplates/announcement-email.html
+++ b/capstone/src/main/webapp/emailTemplates/announcement-email.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="script.js"></script>
     <style>
       .email-content {
         border: 2px double #000;

--- a/capstone/src/main/webapp/emailTemplates/welcome-email.html
+++ b/capstone/src/main/webapp/emailTemplates/welcome-email.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="script.js"></script>
     <style>
       .email-content {
         border: 2px double #000;

--- a/capstone/src/main/webapp/emailTemplates/welcome-email.html
+++ b/capstone/src/main/webapp/emailTemplates/welcome-email.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <script src="script.js"></script>
+    <style>
+      .email-content {
+        border: 2px double #000;
+        color: #000080;
+        font-size: 20px;
+        padding: 20px;
+        background: #f5fcfc;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="email-content">
+      <h2>Welcome to ClubHub!</h2>
+      <h3>Thank you for choosing ClubHub as your platform to connect with clubs across your college campus!</h3>
+      <p>We are excited to see your progress in joining different clubs and growing your network. In the future, 
+          you will receive email notifications whenever a club you have joined posts an announcement.</p>
+      <p>You may also view notifications directly on ClubHub by visiting the <a href="https://clubhub-step-2020.googleplex.com">ClubHub</a> 
+          platform and clicking "My Profile" at the top right corner.</p>
+      <p>Best Regards,<br>The ClubHub Team</p>
+    </div>
+  </body>
+</html>

--- a/capstone/src/test/java/com/google/sps/gmail/EmailFactoryTest.java
+++ b/capstone/src/test/java/com/google/sps/gmail/EmailFactoryTest.java
@@ -43,8 +43,8 @@ import org.mockito.MockitoAnnotations;
 public class EmailFactoryTest {
   private static final String CLUB_1 = "Club 1";
   private static final String MEGHA_EMAIL = "kakm@google.com";
-  private static final String KEVIN_EMAIL = "kshao@google.com";
-  private static final String MEGAN_EMAIL = "meganshi@google.com";
+  //   private static final String KEVIN_EMAIL = "kshao@google.com";
+  //   private static final String MEGAN_EMAIL = "meganshi@google.com";
   private static final String ANNOUNCEMENT = "Here is an announcement";
 
   private Entity club1;
@@ -94,7 +94,7 @@ public class EmailFactoryTest {
 
   @Test
   public void sendEmailToAllMembers_clubWithOnlyOneMember() throws IOException, MessagingException {
-    club1.setProperty(Constants.MEMBER_PROP, ImmutableList.of(MEGAN_EMAIL));
+    club1.setProperty(Constants.MEMBER_PROP, ImmutableList.of(MEGHA_EMAIL));
     datastore.put(club1);
     datastore.put(announcement1);
 
@@ -109,15 +109,14 @@ public class EmailFactoryTest {
   @Test
   public void sendEmailToAllMembers_clubWithMultipleMembers()
       throws IOException, MessagingException {
-    club1.setProperty(
-        Constants.MEMBER_PROP, ImmutableList.of(MEGHA_EMAIL, MEGAN_EMAIL, KEVIN_EMAIL));
+    club1.setProperty(Constants.MEMBER_PROP, ImmutableList.of(MEGHA_EMAIL, "test@example.com"));
     datastore.put(club1);
     datastore.put(announcement1);
 
     ArgumentCaptor<Message> argument = ArgumentCaptor.forClass(Message.class);
     emailFactory.sendEmailToAllMembers(CLUB_1, announcement1);
     // Need to add times(3) because there are 3 recipients of the same email
-    verify(messages, times(3)).send(any(), argument.capture());
+    verify(messages, times(2)).send(any(), argument.capture());
     String body = convertToMimeMessage(argument.getValue()).getContent().toString();
 
     Assert.assertEquals(getEmailContent(CLUB_1, announcement1), body);

--- a/capstone/src/test/java/com/google/sps/gmail/EmailFactoryTest.java
+++ b/capstone/src/test/java/com/google/sps/gmail/EmailFactoryTest.java
@@ -46,8 +46,6 @@ public class EmailFactoryTest {
   private static final String KEVIN_EMAIL = "kshao@google.com";
   private static final String MEGAN_EMAIL = "meganshi@google.com";
   private static final String ANNOUNCEMENT = "Here is an announcement";
-  private static final String EMAIL_PATH =
-      System.getProperty("user.home") + "/step179-2020/capstone/src/main/webapp/emailTemplates";
 
   private Entity club1;
   private Entity announcement1;
@@ -167,7 +165,7 @@ public class EmailFactoryTest {
   }
 
   private String getEmailBody(String path) throws IOException {
-    String fullPath = EMAIL_PATH + path;
+    String fullPath = Constants.EMAIL_PATH + path;
     File htmlTemplate = new File(fullPath);
     String emailBody = FileUtils.readFileToString(htmlTemplate, "utf-8");
     return emailBody;

--- a/capstone/src/test/java/com/google/sps/servlets/student/StudentServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/student/StudentServletTest.java
@@ -44,8 +44,8 @@ public final class StudentServletTest {
   private static final String STUDENT = "student";
   private static final String ANNOUNCEMENTS = "announcements";
   public static final String MEGHA_EMAIL = "kakm@google.com";
-  public static final String KEVIN_EMAIL = "kshao@google.com";
   public static final String MEGAN_EMAIL = "meganshi@google.com";
+  public static final String TEST_EMAIL = "test@example.com";
   public static final String MEGAN_NAME = "Megan Shi";
   public static final String MEGHA_NAME = "Megha Kak";
   public static final int YEAR_2022 = 2022;
@@ -86,7 +86,7 @@ public final class StudentServletTest {
 
     club1 = new Entity("Club");
     club1.setProperty(Constants.PROPERTY_NAME, CLUB_1);
-    club1.setProperty(Constants.MEMBER_PROP, ImmutableList.of(MEGAN_EMAIL));
+    club1.setProperty(Constants.MEMBER_PROP, ImmutableList.of(MEGHA_EMAIL));
 
     club2 = new Entity("Club");
     club2.setProperty(Constants.PROPERTY_NAME, CLUB_2);
@@ -122,9 +122,9 @@ public final class StudentServletTest {
 
   @Test
   public void doGet_studentLogsInForFirstTime() throws ServletException, IOException {
-    localHelper.setEnvEmail(KEVIN_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
+    localHelper.setEnvEmail(TEST_EMAIL).setEnvAuthDomain("example.com").setEnvIsLoggedIn(true);
     when(request.getUserPrincipal()).thenReturn(principal);
-    when(principal.getName()).thenReturn(KEVIN_EMAIL);
+    when(principal.getName()).thenReturn(TEST_EMAIL);
 
     JsonObject responseJson = doGet_studentServletResponse();
     JsonObject responseStudent = responseJson.get(STUDENT).getAsJsonObject();
@@ -137,7 +137,7 @@ public final class StudentServletTest {
         ImmutableList.copyOf(responseStudent.get(Constants.PROPERTY_CLUBS).getAsJsonArray());
 
     Assert.assertEquals("First Last", responseName);
-    Assert.assertEquals(KEVIN_EMAIL, responseEmail);
+    Assert.assertEquals(TEST_EMAIL, responseEmail);
     Assert.assertEquals(0, responseYear);
     Assert.assertEquals("Enter your major here", responseMajor);
     Assert.assertEquals(ImmutableList.of(), responseClubs);
@@ -204,12 +204,13 @@ public final class StudentServletTest {
     announcementEntity.setProperty(Constants.TIME_PROP, System.currentTimeMillis());
     announcementEntity.setProperty(Constants.CONTENT_PROP, announcementContent);
     announcementEntity.setProperty(Constants.CLUB_PROP, CLUB_1);
+    studentMegha.setProperty(Constants.PROPERTY_CLUBS, ImmutableList.of(CLUB_1));
     datastore.put(announcementEntity);
-    datastore.put(studentMegan);
+    datastore.put(studentMegha);
 
-    localHelper.setEnvEmail(MEGAN_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
+    localHelper.setEnvEmail(MEGHA_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
     when(request.getUserPrincipal()).thenReturn(principal);
-    when(principal.getName()).thenReturn(MEGAN_EMAIL);
+    when(principal.getName()).thenReturn(MEGHA_EMAIL);
 
     JsonObject responseJson = doGet_studentServletResponse();
     JsonObject responseStudent = responseJson.get(STUDENT).getAsJsonObject();
@@ -231,11 +232,11 @@ public final class StudentServletTest {
 
     String expectedAnnouncement = getAnnouncement(announcementContent);
 
-    Assert.assertEquals(studentMegan.getProperty(Constants.PROPERTY_NAME), responseName);
-    Assert.assertEquals(studentMegan.getProperty(Constants.PROPERTY_EMAIL), responseEmail);
-    Assert.assertEquals(studentMegan.getProperty(Constants.PROPERTY_GRADYEAR), responseYear);
-    Assert.assertEquals(studentMegan.getProperty(Constants.PROPERTY_MAJOR), responseMajor);
-    Assert.assertEquals(studentMegan.getProperty(Constants.PROPERTY_CLUBS), responseClubs);
+    Assert.assertEquals(studentMegha.getProperty(Constants.PROPERTY_NAME), responseName);
+    Assert.assertEquals(studentMegha.getProperty(Constants.PROPERTY_EMAIL), responseEmail);
+    Assert.assertEquals(studentMegha.getProperty(Constants.PROPERTY_GRADYEAR), responseYear);
+    Assert.assertEquals(studentMegha.getProperty(Constants.PROPERTY_MAJOR), responseMajor);
+    Assert.assertEquals(studentMegha.getProperty(Constants.PROPERTY_CLUBS), responseClubs);
     Assert.assertEquals(expectedAnnouncement, responseAnnouncement);
   }
 


### PR DESCRIPTION
This branch adds an emailTemplates folder with HTML email templates for new announcements and welcome emails. The CSS component of these files must be explicitly written in the HTML files as Gmail requires this to add the CSS styling to the email. In addition, the welcome emails are now sent when a student first logs into ClubHub so the user will know that they have officially joined ClubHub and will receive notifications via email for new announcements in clubs they have joined. Tests have also been added for testing the welcome emails. 