### PR TITLE
Create calendar when club is registered using Calendar API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 .idea
 appengine-generated/
+client_secrets.json

--- a/capstone/pom.xml
+++ b/capstone/pom.xml
@@ -39,10 +39,16 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
-    <dependency>
+    <!-- <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
         <version>2.0.2-beta</version>
+        <scope>test</scope>
+    </dependency> -->
+    <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>2.7.2</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/capstone/pom.xml
+++ b/capstone/pom.xml
@@ -28,6 +28,7 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+    
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -84,6 +85,36 @@
       <artifactId>google-oauth-client-jetty</artifactId>
       <version>1.31.0</version>
     </dependency> 
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-calendar</artifactId>
+      <version>v3-rev20200610-1.30.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-appengine</artifactId>
+      <version>1.36.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client-appengine</artifactId>
+      <version>1.31.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-gson</artifactId>
+      <version>1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client-appengine</artifactId>
+      <version>1.30.9</version>
+    </dependency>
+    <dependency>
+        <groupId>org.json</groupId>
+        <artifactId>json</artifactId>
+        <version>20180130</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/capstone/pom.xml
+++ b/capstone/pom.xml
@@ -39,12 +39,6 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
-    <!-- <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>2.0.2-beta</version>
-        <scope>test</scope>
-    </dependency> -->
     <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>

--- a/capstone/src/main/java/com/google/sps/servlets/Club.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Club.java
@@ -10,6 +10,7 @@ public class Club {
   private String description;
   private String website;
   private String logo;
+  private String calendar;
   private long time;
 
   public Club(
@@ -19,6 +20,7 @@ public class Club {
       String description,
       String website,
       String logo,
+      String calendar,
       long creationTime) {
     this.name = name;
     this.members = members;
@@ -26,6 +28,7 @@ public class Club {
     this.description = description;
     this.website = website;
     this.logo = logo;
+    this.calendar = calendar;
     this.time = creationTime;
   }
 

--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -33,4 +33,5 @@ class Constants {
   static final String NEW_YEAR_PROP = "new-year";
   static final String NEW_MAJOR_PROP = "new-major";
   static final String PROFILE_PIC_PROP = "upload-profile";
+  static final String CALENDAR_PROP = "calendar";
 }

--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -38,5 +38,6 @@ class Constants {
   static final String PROFILE_PIC_PROP = "upload-profile";
   static final String CALENDAR_PROP = "calendar";
   public static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
-  public static final String APPLICATION_NAME = "clubhub-step-2020";
+  public static final String GOOGLE_APPLICATION_NAME = "google.com:clubhub-step-2020";
+  public static final String PST_TIMEZONE = "America/Los_Angeles";
 }

--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -1,5 +1,8 @@
 package com.google.sps.servlets;
 
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+
 /* Stores constants shared between multiple servlets. */
 class Constants {
   private Constants() {}
@@ -34,4 +37,6 @@ class Constants {
   static final String NEW_MAJOR_PROP = "new-major";
   static final String PROFILE_PIC_PROP = "upload-profile";
   static final String CALENDAR_PROP = "calendar";
+  public static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+  public static final String APPLICATION_NAME = "clubhub-step-2020";
 }

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -57,7 +57,7 @@ public class ExploreServlet extends AbstractAppEngineAuthorizationCodeServlet {
         entity.getProperty(Constants.DESCRIP_PROP).toString(),
         entity.getProperty(Constants.WEBSITE_PROP).toString(),
         key,
-        entity.getProperty("calendar").toString(),
+        entity.getProperty(Constants.CALENDAR_PROP).toString(),
         Long.parseLong(entity.getProperty(Constants.TIME_PROP).toString()));
   }
 

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -2,6 +2,8 @@ package com.google.sps.servlets;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
@@ -13,14 +15,14 @@ import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** Servlet that returns some example club content. */
 @WebServlet("/explore")
-public class ExploreServlet extends HttpServlet {
+public class ExploreServlet extends AbstractAppEngineAuthorizationCodeServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Gson gson = new Gson();
@@ -57,6 +59,16 @@ public class ExploreServlet extends HttpServlet {
         key,
         entity.getProperty("calendar").toString(),
         Long.parseLong(entity.getProperty(Constants.TIME_PROP).toString()));
+  }
+
+  @Override
+  protected String getRedirectUri(HttpServletRequest req) throws ServletException, IOException {
+    return ServletUtil.getRedirectUri(req);
+  }
+
+  @Override
+  protected AuthorizationCodeFlow initializeFlow() throws IOException {
+    return ServletUtil.newFlow();
   }
 
   private Comparator<Club> getComparator(String sort) {

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -55,6 +55,7 @@ public class ExploreServlet extends HttpServlet {
         entity.getProperty(Constants.DESCRIP_PROP).toString(),
         entity.getProperty(Constants.WEBSITE_PROP).toString(),
         key,
+        entity.getProperty("calendar").toString(),
         Long.parseLong(entity.getProperty(Constants.TIME_PROP).toString()));
   }
 

--- a/capstone/src/main/java/com/google/sps/servlets/OAuth2CallbackServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/OAuth2CallbackServlet.java
@@ -20,7 +20,6 @@ public class OAuth2CallbackServlet extends AbstractAppEngineAuthorizationCodeCal
   @Override
   protected void onSuccess(HttpServletRequest req, HttpServletResponse resp, Credential credential)
       throws ServletException, IOException {
-    System.out.println(req.getParameter(Constants.SORT_PROP));
     resp.sendRedirect("/explore?sort=" + req.getParameter(Constants.SORT_PROP));
     resp.getWriter().print(userEmail + " is logged in and has given access to their calendar.");
   }

--- a/capstone/src/main/java/com/google/sps/servlets/OAuth2CallbackServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/OAuth2CallbackServlet.java
@@ -20,7 +20,6 @@ public class OAuth2CallbackServlet extends AbstractAppEngineAuthorizationCodeCal
   @Override
   protected void onSuccess(HttpServletRequest req, HttpServletResponse resp, Credential credential)
       throws ServletException, IOException {
-    System.out.println("Hello there this is oauth");
     resp.sendRedirect("/explore");
     resp.getWriter().print(userEmail + " is logged in and has given access to their calendar.");
   }

--- a/capstone/src/main/java/com/google/sps/servlets/OAuth2CallbackServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/OAuth2CallbackServlet.java
@@ -20,7 +20,7 @@ public class OAuth2CallbackServlet extends AbstractAppEngineAuthorizationCodeCal
   @Override
   protected void onSuccess(HttpServletRequest req, HttpServletResponse resp, Credential credential)
       throws ServletException, IOException {
-    resp.sendRedirect("/explore");
+    resp.sendRedirect("/explore?sort=" + req.getParameter(Constants.SORT_PROP));
     resp.getWriter().print(userEmail + " is logged in and has given access to their calendar.");
   }
 

--- a/capstone/src/main/java/com/google/sps/servlets/OAuth2CallbackServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/OAuth2CallbackServlet.java
@@ -1,0 +1,46 @@
+package com.google.sps.servlets;
+
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.auth.oauth2.AuthorizationCodeResponseUrl;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeCallbackServlet;
+import com.google.appengine.api.users.UserServiceFactory;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+// Callback servlet handles callbacks for OAuth.
+@WebServlet("/oauth2callback")
+public class OAuth2CallbackServlet extends AbstractAppEngineAuthorizationCodeCallbackServlet {
+  String userEmail = UserServiceFactory.getUserService().getCurrentUser().getEmail();
+
+  // On success the callback servlet redirects to the main servlet.
+  @Override
+  protected void onSuccess(HttpServletRequest req, HttpServletResponse resp, Credential credential)
+      throws ServletException, IOException {
+    System.out.println("Hello there this is oauth");
+    resp.sendRedirect("/explore");
+    resp.getWriter().print(userEmail + " is logged in and has given access to their calendar.");
+  }
+
+  // On failure (i.e user denies access) the callback servlet displays a simple error message."
+  @Override
+  protected void onError(
+      HttpServletRequest req, HttpServletResponse resp, AuthorizationCodeResponseUrl errorResponse)
+      throws ServletException, IOException {
+    resp.getWriter().print(userEmail + " has not given access to their calendar");
+    resp.setStatus(200);
+  }
+
+  @Override
+  protected String getRedirectUri(HttpServletRequest req) throws ServletException, IOException {
+    return ServletUtil.getRedirectUri(req);
+  }
+
+  @Override
+  protected AuthorizationCodeFlow initializeFlow() throws IOException {
+    return ServletUtil.newFlow();
+  }
+}

--- a/capstone/src/main/java/com/google/sps/servlets/OAuth2CallbackServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/OAuth2CallbackServlet.java
@@ -20,6 +20,7 @@ public class OAuth2CallbackServlet extends AbstractAppEngineAuthorizationCodeCal
   @Override
   protected void onSuccess(HttpServletRequest req, HttpServletResponse resp, Credential credential)
       throws ServletException, IOException {
+    System.out.println(req.getParameter(Constants.SORT_PROP));
     resp.sendRedirect("/explore?sort=" + req.getParameter(Constants.SORT_PROP));
     resp.getWriter().print(userEmail + " is logged in and has given access to their calendar.");
   }

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
@@ -103,6 +103,7 @@ public class AnnouncementsServlet extends HttpServlet {
         entity.getProperty(Constants.DESCRIP_PROP).toString(),
         entity.getProperty(Constants.WEBSITE_PROP).toString(),
         key,
+        entity.getProperty("calendar").toString(),
         Long.parseLong(entity.getProperty(Constants.TIME_PROP).toString()));
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
@@ -115,7 +115,7 @@ public class AnnouncementsServlet extends AbstractAppEngineAuthorizationCodeServ
         entity.getProperty(Constants.DESCRIP_PROP).toString(),
         entity.getProperty(Constants.WEBSITE_PROP).toString(),
         key,
-        entity.getProperty("calendar").toString(),
+        entity.getProperty(Constants.CALENDAR_PROP).toString(),
         Long.parseLong(entity.getProperty(Constants.TIME_PROP).toString()));
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/AnnouncementsServlet.java
@@ -2,6 +2,8 @@ package com.google.sps.servlets;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
@@ -14,14 +16,14 @@ import com.google.common.collect.Streams;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.ArrayList;
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** Servlet that returns some example club content */
 @WebServlet("/announcements")
-public class AnnouncementsServlet extends HttpServlet {
+public class AnnouncementsServlet extends AbstractAppEngineAuthorizationCodeServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -80,6 +82,16 @@ public class AnnouncementsServlet extends HttpServlet {
     datastore.put(announcementEntity);
 
     response.sendRedirect("/about-us.html?name=" + clubName + "&tab=announcements");
+  }
+
+  @Override
+  protected String getRedirectUri(HttpServletRequest req) throws ServletException, IOException {
+    return ServletUtil.getRedirectUri(req);
+  }
+
+  @Override
+  protected AuthorizationCodeFlow initializeFlow() throws IOException {
+    return ServletUtil.newFlow();
   }
 
   private Club getClub(DatastoreService datastore, String clubName) {

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/DeleteAnnouncementServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/DeleteAnnouncementServlet.java
@@ -2,6 +2,8 @@ package com.google.sps.servlets;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
@@ -17,14 +19,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import java.io.IOException;
 import java.util.Arrays;
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** Servlet that returns some example club content */
 @WebServlet("/delete-announcement")
-public class DeleteAnnouncementServlet extends HttpServlet {
+public class DeleteAnnouncementServlet extends AbstractAppEngineAuthorizationCodeServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -57,5 +59,15 @@ public class DeleteAnnouncementServlet extends HttpServlet {
     datastore.delete(comments);
 
     response.sendRedirect("/about-us.html?name=" + clubName + "&tab=announcements");
+  }
+
+  @Override
+  protected String getRedirectUri(HttpServletRequest req) throws ServletException, IOException {
+    return ServletUtil.getRedirectUri(req);
+  }
+
+  @Override
+  protected AuthorizationCodeFlow initializeFlow() throws IOException {
+    return ServletUtil.newFlow();
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/announcements/EditAnnouncementServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/announcements/EditAnnouncementServlet.java
@@ -2,6 +2,8 @@ package com.google.sps.servlets;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
@@ -10,14 +12,14 @@ import com.google.appengine.api.datastore.Query;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import java.io.IOException;
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** Servlet that returns some example club content */
 @WebServlet("/edit-announcement")
-public class EditAnnouncementServlet extends HttpServlet {
+public class EditAnnouncementServlet extends AbstractAppEngineAuthorizationCodeServlet {
 
   private final String ID_PROP = "id";
 
@@ -61,5 +63,15 @@ public class EditAnnouncementServlet extends HttpServlet {
                                 + entity.getProperty(Constants.TIME_PROP).toString()))
             .collect(toImmutableList());
     return entities;
+  }
+
+  @Override
+  protected String getRedirectUri(HttpServletRequest req) throws ServletException, IOException {
+    return ServletUtil.getRedirectUri(req);
+  }
+
+  @Override
+  protected AuthorizationCodeFlow initializeFlow() throws IOException {
+    return ServletUtil.newFlow();
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -1,19 +1,13 @@
 package com.google.sps.servlets;
 
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
 import com.google.api.client.auth.oauth2.Credential;
-import com.google.api.client.extensions.appengine.datastore.AppEngineDataStoreFactory;
+import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
 import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
-import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
-import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
-import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
-import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.calendar.Calendar;
-import com.google.api.services.calendar.CalendarScopes;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
@@ -27,50 +21,22 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
-import java.io.BufferedReader;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLEncoder;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.json.JSONObject;
 
 /* Servlet that stores and returns data relating to clubs. */
 @WebServlet("/clubs")
-public class ClubServlet extends HttpServlet {
+public class ClubServlet extends AbstractAppEngineAuthorizationCodeServlet {
   private final String SCOPE_TYPE = "user";
   private final String USER_CALENDAR_PERMISSIONS = "reader";
+  private static final HttpTransport HTTP_TRANSPORT = UrlFetchTransport.getDefaultInstance();
   protected static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
-  protected static final List<String> SCOPES =
-      ImmutableList.of(
-          "https://www.googleapis.com/auth/calendar",
-          "https://www.googleapis.com/auth/calendar.events",
-          "https://www.googleapis.com/auth/calendar.events.readonly",
-          "https://www.googleapis.com/auth/calendar.readonly",
-          "https://www.googleapis.com/auth/calendar.settings.readonly",
-          "https://www.googleapis.com/calendar/v3/calendars",
-          "https://www.googleapis.com/auth/calendar.events.public.readonly",
-          "https://www.googleapis.com/auth/calendar.app.created");
-  private static final String CREDENTIALS_FILE_PATH =
-      "/tmp/tmp.OF0kWf8TmL/application_default_credentials.json";
-  private static final String TOKENS_DIRECTORY_PATH = "tokens";
-  private static final String CLIENT_ID =
-      "264953829929-ffv5q12afu4a7bm3vd7pnlfg8d96tlom.apps.googleusercontent.com";
-  private static final String CLIENT_SECRET = "-g4ch6SGO-gu5CCpoY6pQ9qH";
-  private static final String REFRESH_TOKEN =
-      "4/3AGw35EXK_fBdvnlMvImHlYf86ulkGJJsG8eOUYIJqik0I1ceAJtucEwV_ilQYjGJXNW7_GT_YRK2MiO4faLwGY";
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -90,7 +56,7 @@ public class ClubServlet extends HttpServlet {
       if (clubEntity.getProperty(Constants.LOGO_PROP) != null) {
         logoKey = clubEntity.getProperty(Constants.LOGO_PROP).toString();
       }
-      String calendar = clubEntity.getProperty("calendar").toString();
+      String calendar = clubEntity.getProperty(Constants.CALENDAR_PROP).toString();
       boolean isOfficer = officers.contains(userEmail);
       long creationTime = Long.parseLong(clubEntity.getProperty(Constants.TIME_PROP).toString());
       Club club =
@@ -118,10 +84,8 @@ public class ClubServlet extends HttpServlet {
     // Must use UserService to access logged in user here
     UserService userService = UserServiceFactory.getUserService();
     String founderEmail = userService.getCurrentUser().getEmail();
-    // String userEmail = request.getUserPrincipal().getName();
 
     // Check if club name is valid
-
     PreparedQuery prepared = retrieveClub(request, datastore);
     boolean isValid = Iterables.isEmpty(prepared.asIterable());
 
@@ -129,16 +93,12 @@ public class ClubServlet extends HttpServlet {
       String clubName = request.getParameter(Constants.PROPERTY_NAME);
       String description = request.getParameter(Constants.DESCRIP_PROP);
       String website = request.getParameter(Constants.WEBSITE_PROP);
-      String calendarId;
+      String calendarId = "";
       try {
         calendarId = createCalendar(clubName);
-        // setGroupCalendarId(clubName, calendarId);
       } catch (Exception entityError) {
-        System.out.println("error is: " + entityError);
-        calendarId = entityError.toString();
-        // response.getWriter().println("Error");
+        response.getWriter().println("Error");
       }
-      //   calendarId = createCalendar(clubName);
       Entity clubEntity = new Entity(Constants.CLUB_ENTITY_PROP, clubName);
       clubEntity.setProperty(Constants.PROPERTY_NAME, clubName);
       clubEntity.setProperty(Constants.DESCRIP_PROP, description);
@@ -147,7 +107,7 @@ public class ClubServlet extends HttpServlet {
       clubEntity.setProperty(Constants.OFFICER_PROP, ImmutableList.of(founderEmail));
       clubEntity.setProperty(Constants.TIME_PROP, System.currentTimeMillis());
       clubEntity.setProperty(Constants.LOGO_PROP, "");
-      clubEntity.setProperty("calendar", calendarId);
+      clubEntity.setProperty(Constants.CALENDAR_PROP, calendarId);
       datastore.put(clubEntity);
       addClubToFoundersClubList(datastore, founderEmail, clubName);
     }
@@ -189,127 +149,35 @@ public class ClubServlet extends HttpServlet {
   public String createCalendar(String clubName) throws IOException, GeneralSecurityException {
     com.google.api.services.calendar.model.Calendar calendar =
         new com.google.api.services.calendar.model.Calendar()
-            .setSummary(clubName + " calendar")
+            .setSummary(clubName + " Calendar")
             .setTimeZone("America/Los_Angeles");
     Calendar service = getCalendarService();
     String createdCalendarId = service.calendars().insert(calendar).execute().getId();
-    System.out.println("id: " + createdCalendarId);
 
+    // TODO: set up permissions for club members (read only) and officers (read and write)
     // Enable reader permission for user
     // AclRule rule =
     //     new AclRule().setScope(new
     // Scope().setType(SCOPE_TYPE)).setRole(USER_CALENDAR_PERMISSIONS);
     // service.acl().insert(createdCalendarId, rule).execute();
-
     return createdCalendarId;
   }
 
   private Calendar getCalendarService() throws IOException, GeneralSecurityException {
-    // final NetHttpTransport HTTP_TRANSPORT = GoogleNetHttpTransport.newTrustedTransport();
-    final HttpTransport HTTP_TRANSPORT = UrlFetchTransport.getDefaultInstance();
-    // Credential credential =
-    //     new GoogleCredential.Builder()
-    //         .setTransport(GoogleNetHttpTransport.newTrustedTransport())
-    //         .setJsonFactory(JSON_FACTORY)
-    //         .setClientSecrets(CLIENT_ID, CLIENT_SECRET)
-    //         .build()
-    //         .setAccessToken(getAccessToken())
-    //         .setRefreshToken(REFRESH_TOKEN);
     String userId = UserServiceFactory.getUserService().getCurrentUser().getUserId();
-    Credential credential = newFlow().loadCredential(userId);
+    Credential credential = ServletUtil.newFlow().loadCredential(userId);
     return new Calendar.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential)
         .setApplicationName("google.com:clubhub-step-2020")
         .build();
-
-    // return new Calendar.Builder(
-    //         HTTP_TRANSPORT, JSON_FACTORY, new AppIdentityCredential(CalendarScopes.all()))
-    //     .setApplicationName("google.com:clubhub-step-2020")
-    //     .build();
-
-    // return new Calendar.Builder(HTTP_TRANSPORT, JSON_FACTORY, getCredentials(HTTP_TRANSPORT))
-    //     .setApplicationName("google.com:clubhub-step-2020")
-    //     .build();
   }
 
-  private static Credential getCredentials(final HttpTransport HTTP_TRANSPORT) throws IOException {
-    // Load client secrets.
-    InputStream in = ClubServlet.class.getResourceAsStream(CREDENTIALS_FILE_PATH);
-    if (in == null) {
-      throw new FileNotFoundException("Resource not found: " + CREDENTIALS_FILE_PATH);
-    }
-    GoogleClientSecrets clientSecrets =
-        GoogleClientSecrets.load(JSON_FACTORY, new InputStreamReader(in));
-
-    // Build flow and trigger user authorization request.
-    GoogleAuthorizationCodeFlow flow =
-        new GoogleAuthorizationCodeFlow.Builder(HTTP_TRANSPORT, JSON_FACTORY, clientSecrets, SCOPES)
-            .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
-            .setAccessType("offline")
-            .build();
-    LocalServerReceiver receiver = new LocalServerReceiver.Builder().setPort(8888).build();
-    return new AuthorizationCodeInstalledApp(flow, receiver).authorize("user");
+  @Override
+  protected String getRedirectUri(HttpServletRequest req) throws ServletException, IOException {
+    return ServletUtil.getRedirectUri(req);
   }
 
-  private static String getAccessToken() {
-    try {
-      Map<String, Object> params = new LinkedHashMap<>();
-      params.put("grant_type", "refresh_token");
-      params.put("client_id", CLIENT_ID);
-      params.put("client_secret", CLIENT_SECRET);
-      params.put("refresh_token", REFRESH_TOKEN);
-
-      StringBuilder postData = new StringBuilder();
-      for (Map.Entry<String, Object> param : params.entrySet()) {
-        if (postData.length() != 0) {
-          postData.append('&');
-        }
-        postData.append(URLEncoder.encode(param.getKey(), "UTF-8"));
-        postData.append('=');
-        postData.append(URLEncoder.encode(String.valueOf(param.getValue()), "UTF-8"));
-      }
-
-      byte[] postDataBytes = postData.toString().getBytes("UTF-8");
-
-      URL url = new URL("https://accounts.google.com/o/oauth2/token");
-      HttpURLConnection con = (HttpURLConnection) url.openConnection();
-      con.setDoOutput(true);
-      con.setUseCaches(false);
-      con.setRequestMethod("POST");
-      con.getOutputStream().write(postDataBytes);
-
-      BufferedReader reader = new BufferedReader(new InputStreamReader(con.getInputStream()));
-      StringBuffer buffer = new StringBuffer();
-      for (String line = reader.readLine(); line != null; line = reader.readLine()) {
-        buffer.append(line);
-      }
-
-      JSONObject json = new JSONObject(buffer.toString());
-      String accessToken = json.getString("access_token");
-      return accessToken;
-    } catch (Exception ex) {
-      ex.printStackTrace();
-    }
-    return null;
-  }
-
-  static GoogleAuthorizationCodeFlow newFlow() throws IOException {
-    return new GoogleAuthorizationCodeFlow.Builder(
-            new NetHttpTransport(),
-            JacksonFactory.getDefaultInstance(),
-            getClientCredential(),
-            Collections.singleton(CalendarScopes.CALENDAR))
-        .setDataStoreFactory(AppEngineDataStoreFactory.getDefaultInstance())
-        .setAccessType("offline")
-        .build();
-  }
-
-  static GoogleClientSecrets getClientCredential() throws IOException {
-    System.out.println(ClubServlet.class.getResourceAsStream("/client_secrets.json"));
-    GoogleClientSecrets clientSecrets =
-        GoogleClientSecrets.load(
-            JSON_FACTORY,
-            new InputStreamReader(ClubServlet.class.getResourceAsStream("/client_secrets.json")));
-
-    return clientSecrets;
+  @Override
+  protected AuthorizationCodeFlow initializeFlow() throws IOException {
+    return ServletUtil.newFlow();
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -151,20 +151,13 @@ public class ClubServlet extends AbstractAppEngineAuthorizationCodeServlet {
   }
 
   /** Return the Calendar ID after creating a calendar for the given club name. */
-  public String createCalendar(String clubName, Calendar service)
+  private String createCalendar(String clubName, Calendar service)
       throws IOException, GeneralSecurityException {
     com.google.api.services.calendar.model.Calendar calendar =
         new com.google.api.services.calendar.model.Calendar()
             .setSummary(clubName + " Calendar")
             .setTimeZone(Constants.PST_TIMEZONE);
     String createdCalendarId = service.calendars().insert(calendar).execute().getId();
-
-    // TODO: set up permissions for club members (read only) and officers (read and write)
-    // Enable reader permission for user
-    // AclRule rule =
-    //     new AclRule().setScope(new
-    // Scope().setType(SCOPE_TYPE)).setRole(USER_CALENDAR_PERMISSIONS);
-    // service.acl().insert(createdCalendarId, rule).execute();
     return createdCalendarId;
   }
 

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -5,8 +5,6 @@ import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
 import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.calendar.Calendar;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -36,7 +34,6 @@ public class ClubServlet extends AbstractAppEngineAuthorizationCodeServlet {
   private final String SCOPE_TYPE = "user";
   private final String USER_CALENDAR_PERMISSIONS = "reader";
   private static final HttpTransport HTTP_TRANSPORT = UrlFetchTransport.getDefaultInstance();
-  protected static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -174,8 +171,8 @@ public class ClubServlet extends AbstractAppEngineAuthorizationCodeServlet {
   private Calendar getCalendarService() throws IOException, GeneralSecurityException {
     String userId = UserServiceFactory.getUserService().getCurrentUser().getUserId();
     Credential credential = ServletUtil.newFlow().loadCredential(userId);
-    return new Calendar.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential)
-        .setApplicationName("google.com:clubhub-step-2020")
+    return new Calendar.Builder(HTTP_TRANSPORT, Constants.JSON_FACTORY, credential)
+        .setApplicationName(Constants.APPLICATION_NAME)
         .build();
   }
 

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -156,7 +156,7 @@ public class ClubServlet extends AbstractAppEngineAuthorizationCodeServlet {
     com.google.api.services.calendar.model.Calendar calendar =
         new com.google.api.services.calendar.model.Calendar()
             .setSummary(clubName + " Calendar")
-            .setTimeZone("America/Los_Angeles");
+            .setTimeZone(Constants.PST_TIMEZONE);
     String createdCalendarId = service.calendars().insert(calendar).execute().getId();
 
     // TODO: set up permissions for club members (read only) and officers (read and write)
@@ -172,7 +172,7 @@ public class ClubServlet extends AbstractAppEngineAuthorizationCodeServlet {
     String userId = UserServiceFactory.getUserService().getCurrentUser().getUserId();
     Credential credential = ServletUtil.newFlow().loadCredential(userId);
     return new Calendar.Builder(HTTP_TRANSPORT, Constants.JSON_FACTORY, credential)
-        .setApplicationName(Constants.APPLICATION_NAME)
+        .setApplicationName(Constants.GOOGLE_APPLICATION_NAME)
         .build();
   }
 

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -1,5 +1,19 @@
 package com.google.sps.servlets;
 
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.extensions.appengine.datastore.AppEngineDataStoreFactory;
+import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
+import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
+import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.store.FileDataStoreFactory;
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.CalendarScopes;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
@@ -13,17 +27,50 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.json.JSONObject;
 
 /* Servlet that stores and returns data relating to clubs. */
 @WebServlet("/clubs")
 public class ClubServlet extends HttpServlet {
+  private final String SCOPE_TYPE = "user";
+  private final String USER_CALENDAR_PERMISSIONS = "reader";
+  protected static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+  protected static final List<String> SCOPES =
+      ImmutableList.of(
+          "https://www.googleapis.com/auth/calendar",
+          "https://www.googleapis.com/auth/calendar.events",
+          "https://www.googleapis.com/auth/calendar.events.readonly",
+          "https://www.googleapis.com/auth/calendar.readonly",
+          "https://www.googleapis.com/auth/calendar.settings.readonly",
+          "https://www.googleapis.com/calendar/v3/calendars",
+          "https://www.googleapis.com/auth/calendar.events.public.readonly",
+          "https://www.googleapis.com/auth/calendar.app.created");
+  private static final String CREDENTIALS_FILE_PATH =
+      "/tmp/tmp.OF0kWf8TmL/application_default_credentials.json";
+  private static final String TOKENS_DIRECTORY_PATH = "tokens";
+  private static final String CLIENT_ID =
+      "264953829929-ffv5q12afu4a7bm3vd7pnlfg8d96tlom.apps.googleusercontent.com";
+  private static final String CLIENT_SECRET = "-g4ch6SGO-gu5CCpoY6pQ9qH";
+  private static final String REFRESH_TOKEN =
+      "4/3AGw35EXK_fBdvnlMvImHlYf86ulkGJJsG8eOUYIJqik0I1ceAJtucEwV_ilQYjGJXNW7_GT_YRK2MiO4faLwGY";
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -43,9 +90,11 @@ public class ClubServlet extends HttpServlet {
       if (clubEntity.getProperty(Constants.LOGO_PROP) != null) {
         logoKey = clubEntity.getProperty(Constants.LOGO_PROP).toString();
       }
+      String calendar = clubEntity.getProperty("calendar").toString();
       boolean isOfficer = officers.contains(userEmail);
       long creationTime = Long.parseLong(clubEntity.getProperty(Constants.TIME_PROP).toString());
-      Club club = new Club(name, members, officers, description, website, logoKey, creationTime);
+      Club club =
+          new Club(name, members, officers, description, website, logoKey, calendar, creationTime);
       Gson gson = new Gson();
       JsonElement jsonElement = gson.toJsonTree(club);
       jsonElement.getAsJsonObject().addProperty("isOfficer", isOfficer);
@@ -69,6 +118,7 @@ public class ClubServlet extends HttpServlet {
     // Must use UserService to access logged in user here
     UserService userService = UserServiceFactory.getUserService();
     String founderEmail = userService.getCurrentUser().getEmail();
+    // String userEmail = request.getUserPrincipal().getName();
 
     // Check if club name is valid
 
@@ -79,6 +129,16 @@ public class ClubServlet extends HttpServlet {
       String clubName = request.getParameter(Constants.PROPERTY_NAME);
       String description = request.getParameter(Constants.DESCRIP_PROP);
       String website = request.getParameter(Constants.WEBSITE_PROP);
+      String calendarId;
+      try {
+        calendarId = createCalendar(clubName);
+        // setGroupCalendarId(clubName, calendarId);
+      } catch (Exception entityError) {
+        System.out.println("error is: " + entityError);
+        calendarId = entityError.toString();
+        // response.getWriter().println("Error");
+      }
+      //   calendarId = createCalendar(clubName);
       Entity clubEntity = new Entity(Constants.CLUB_ENTITY_PROP, clubName);
       clubEntity.setProperty(Constants.PROPERTY_NAME, clubName);
       clubEntity.setProperty(Constants.DESCRIP_PROP, description);
@@ -87,8 +147,8 @@ public class ClubServlet extends HttpServlet {
       clubEntity.setProperty(Constants.OFFICER_PROP, ImmutableList.of(founderEmail));
       clubEntity.setProperty(Constants.TIME_PROP, System.currentTimeMillis());
       clubEntity.setProperty(Constants.LOGO_PROP, "");
+      clubEntity.setProperty("calendar", calendarId);
       datastore.put(clubEntity);
-
       addClubToFoundersClubList(datastore, founderEmail, clubName);
     }
     response.sendRedirect("/registration-msg.html?is-valid=" + isValid);
@@ -123,5 +183,133 @@ public class ClubServlet extends HttpServlet {
                     request.getParameter(Constants.PROPERTY_NAME)));
     PreparedQuery prepared = datastore.prepare(query);
     return prepared;
+  }
+
+  /** Return the Calendar ID after creating a calendar for the given club name. */
+  public String createCalendar(String clubName) throws IOException, GeneralSecurityException {
+    com.google.api.services.calendar.model.Calendar calendar =
+        new com.google.api.services.calendar.model.Calendar()
+            .setSummary(clubName + " calendar")
+            .setTimeZone("America/Los_Angeles");
+    Calendar service = getCalendarService();
+    String createdCalendarId = service.calendars().insert(calendar).execute().getId();
+    System.out.println("id: " + createdCalendarId);
+
+    // Enable reader permission for user
+    // AclRule rule =
+    //     new AclRule().setScope(new
+    // Scope().setType(SCOPE_TYPE)).setRole(USER_CALENDAR_PERMISSIONS);
+    // service.acl().insert(createdCalendarId, rule).execute();
+
+    return createdCalendarId;
+  }
+
+  private Calendar getCalendarService() throws IOException, GeneralSecurityException {
+    // final NetHttpTransport HTTP_TRANSPORT = GoogleNetHttpTransport.newTrustedTransport();
+    final HttpTransport HTTP_TRANSPORT = UrlFetchTransport.getDefaultInstance();
+    // Credential credential =
+    //     new GoogleCredential.Builder()
+    //         .setTransport(GoogleNetHttpTransport.newTrustedTransport())
+    //         .setJsonFactory(JSON_FACTORY)
+    //         .setClientSecrets(CLIENT_ID, CLIENT_SECRET)
+    //         .build()
+    //         .setAccessToken(getAccessToken())
+    //         .setRefreshToken(REFRESH_TOKEN);
+    String userId = UserServiceFactory.getUserService().getCurrentUser().getUserId();
+    Credential credential = newFlow().loadCredential(userId);
+    return new Calendar.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential)
+        .setApplicationName("google.com:clubhub-step-2020")
+        .build();
+
+    // return new Calendar.Builder(
+    //         HTTP_TRANSPORT, JSON_FACTORY, new AppIdentityCredential(CalendarScopes.all()))
+    //     .setApplicationName("google.com:clubhub-step-2020")
+    //     .build();
+
+    // return new Calendar.Builder(HTTP_TRANSPORT, JSON_FACTORY, getCredentials(HTTP_TRANSPORT))
+    //     .setApplicationName("google.com:clubhub-step-2020")
+    //     .build();
+  }
+
+  private static Credential getCredentials(final HttpTransport HTTP_TRANSPORT) throws IOException {
+    // Load client secrets.
+    InputStream in = ClubServlet.class.getResourceAsStream(CREDENTIALS_FILE_PATH);
+    if (in == null) {
+      throw new FileNotFoundException("Resource not found: " + CREDENTIALS_FILE_PATH);
+    }
+    GoogleClientSecrets clientSecrets =
+        GoogleClientSecrets.load(JSON_FACTORY, new InputStreamReader(in));
+
+    // Build flow and trigger user authorization request.
+    GoogleAuthorizationCodeFlow flow =
+        new GoogleAuthorizationCodeFlow.Builder(HTTP_TRANSPORT, JSON_FACTORY, clientSecrets, SCOPES)
+            .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
+            .setAccessType("offline")
+            .build();
+    LocalServerReceiver receiver = new LocalServerReceiver.Builder().setPort(8888).build();
+    return new AuthorizationCodeInstalledApp(flow, receiver).authorize("user");
+  }
+
+  private static String getAccessToken() {
+    try {
+      Map<String, Object> params = new LinkedHashMap<>();
+      params.put("grant_type", "refresh_token");
+      params.put("client_id", CLIENT_ID);
+      params.put("client_secret", CLIENT_SECRET);
+      params.put("refresh_token", REFRESH_TOKEN);
+
+      StringBuilder postData = new StringBuilder();
+      for (Map.Entry<String, Object> param : params.entrySet()) {
+        if (postData.length() != 0) {
+          postData.append('&');
+        }
+        postData.append(URLEncoder.encode(param.getKey(), "UTF-8"));
+        postData.append('=');
+        postData.append(URLEncoder.encode(String.valueOf(param.getValue()), "UTF-8"));
+      }
+
+      byte[] postDataBytes = postData.toString().getBytes("UTF-8");
+
+      URL url = new URL("https://accounts.google.com/o/oauth2/token");
+      HttpURLConnection con = (HttpURLConnection) url.openConnection();
+      con.setDoOutput(true);
+      con.setUseCaches(false);
+      con.setRequestMethod("POST");
+      con.getOutputStream().write(postDataBytes);
+
+      BufferedReader reader = new BufferedReader(new InputStreamReader(con.getInputStream()));
+      StringBuffer buffer = new StringBuffer();
+      for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+        buffer.append(line);
+      }
+
+      JSONObject json = new JSONObject(buffer.toString());
+      String accessToken = json.getString("access_token");
+      return accessToken;
+    } catch (Exception ex) {
+      ex.printStackTrace();
+    }
+    return null;
+  }
+
+  static GoogleAuthorizationCodeFlow newFlow() throws IOException {
+    return new GoogleAuthorizationCodeFlow.Builder(
+            new NetHttpTransport(),
+            JacksonFactory.getDefaultInstance(),
+            getClientCredential(),
+            Collections.singleton(CalendarScopes.CALENDAR))
+        .setDataStoreFactory(AppEngineDataStoreFactory.getDefaultInstance())
+        .setAccessType("offline")
+        .build();
+  }
+
+  static GoogleClientSecrets getClientCredential() throws IOException {
+    System.out.println(ClubServlet.class.getResourceAsStream("/client_secrets.json"));
+    GoogleClientSecrets clientSecrets =
+        GoogleClientSecrets.load(
+            JSON_FACTORY,
+            new InputStreamReader(ClubServlet.class.getResourceAsStream("/client_secrets.json")));
+
+    return clientSecrets;
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/EditClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/EditClubServlet.java
@@ -14,10 +14,13 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
 
 /* Servlet that stores and returns data relating to clubs. */
 @WebServlet("/club-edit")
-public class EditClubServlet extends HttpServlet {
+public class EditClubServlet extends AbstractAppEngineAuthorizationCodeServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
@@ -66,5 +69,15 @@ public class EditClubServlet extends HttpServlet {
               + "&is-invalid="
               + isInvalid);
     }
+  }
+
+  @Override
+  protected String getRedirectUri(HttpServletRequest req) throws ServletException, IOException {
+    return ServletUtil.getRedirectUri(req);
+  }
+
+  @Override
+  protected AuthorizationCodeFlow initializeFlow() throws IOException {
+    return ServletUtil.newFlow();
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/EditClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/EditClubServlet.java
@@ -2,6 +2,8 @@ package com.google.sps.servlets;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
@@ -10,13 +12,10 @@ import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.ServletException;
-import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
-import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
 
 /* Servlet that stores and returns data relating to clubs. */
 @WebServlet("/club-edit")

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/OfficerServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/OfficerServlet.java
@@ -2,6 +2,9 @@ package com.google.sps.servlets;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import javax.servlet.ServletException;
+import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.FilterOperator;
@@ -14,7 +17,7 @@ import javax.servlet.http.HttpServletResponse;
 
 /* Servlet that stores and returns data relating to clubs. */
 @WebServlet("/officer")
-public class OfficerServlet extends HttpServlet {
+public class OfficerServlet extends AbstractAppEngineAuthorizationCodeServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -36,5 +39,15 @@ public class OfficerServlet extends HttpServlet {
       return false;
     }
     return ServletUtil.getPropertyList(entity, Constants.OFFICER_PROP).contains(user);
+  }
+
+  @Override
+  protected String getRedirectUri(HttpServletRequest req) throws ServletException, IOException {
+    return ServletUtil.getRedirectUri(req);
+  }
+
+  @Override
+  protected AuthorizationCodeFlow initializeFlow() throws IOException {
+    return ServletUtil.newFlow();
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/OfficerServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/OfficerServlet.java
@@ -1,17 +1,16 @@
 package com.google.sps.servlets;
 
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import javax.servlet.ServletException;
-import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
-import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import java.io.IOException;
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 

--- a/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
+++ b/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
@@ -5,8 +5,6 @@ import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.calendar.CalendarScopes;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -21,9 +19,9 @@ import java.util.Collections;
 import javax.servlet.http.HttpServletRequest;
 
 public final class ServletUtil {
-  static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
   static final HttpTransport HTTP_TRANSPORT = new UrlFetchTransport();
   private static GoogleClientSecrets clientSecrets = null;
+  private static final String OFFLINE_ACCESS_TYPE = "offline";
 
   public static ImmutableList<String> getPropertyList(Entity entity, String property) {
     if (entity.getProperty(property) != null) {
@@ -48,24 +46,26 @@ public final class ServletUtil {
     // If you want to run this locally, you will need to replace this with your dev server URI
     // - then add "/oauth2callback" to the end of it and add that to you API console under
     // Authorized URIs.
-    return "https://8080-4417b0ad-e7ff-4d2f-acc8-c9ddcf7b56d9.us-west1.cloudshell.dev/oauth2callback";
+    // return
+    // "https://8080-4417b0ad-e7ff-4d2f-acc8-c9ddcf7b56d9.us-west1.cloudshell.dev/oauth2callback";
+    return "https://clubhub-step-2020.googleplex.com/oauth2callback";
   }
 
   public static GoogleAuthorizationCodeFlow newFlow() throws IOException {
     return new GoogleAuthorizationCodeFlow.Builder(
             HTTP_TRANSPORT,
-            JSON_FACTORY,
+            Constants.JSON_FACTORY,
             getClientCredential(),
             Collections.singleton(CalendarScopes.CALENDAR))
         .setDataStoreFactory(AppEngineDataStoreFactory.getDefaultInstance())
-        .setAccessType("offline")
+        .setAccessType(OFFLINE_ACCESS_TYPE)
         .build();
   }
 
   static GoogleClientSecrets getClientCredential() throws IOException {
     GoogleClientSecrets clientSecrets =
         GoogleClientSecrets.load(
-            JSON_FACTORY,
+            Constants.JSON_FACTORY,
             new InputStreamReader(ServletUtil.class.getResourceAsStream("/client_secrets.json")));
     return clientSecrets;
   }

--- a/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
+++ b/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
@@ -1,17 +1,24 @@
 package com.google.sps.servlets;
 
+import com.google.api.client.extensions.appengine.datastore.AppEngineDataStoreFactory;
 import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.calendar.CalendarScopes;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Collections;
+import javax.servlet.http.HttpServletRequest;
 
 public final class ServletUtil {
   static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
@@ -36,32 +43,30 @@ public final class ServletUtil {
     return entity.getProperty(Constants.PROPERTY_NAME).toString();
   }
 
-  //   // Loads client secrets from a stored file
-  //   public static GoogleClientSecrets getClientCredential() throws IOException {
-  //     if (clientSecrets == null) {
-  //       clientSecrets =
-  //           GoogleClientSecrets.load(
-  //               JSON_FACTORY,
-  //               new
-  // InputStreamReader(ServletUtil.class.getResourceAsStream("/client_secrets.json")));
-  //     }
-  //     return clientSecrets;
-  //   }
+  public static String getRedirectUri(HttpServletRequest req) {
+    // TODO: change redirect URI when web app is deployed.
+    // If you want to run this locally, you will need to replace this with your dev server URI
+    // - then add "/oauth2callback" to the end of it and add that to you API console under
+    // Authorized URIs.
+    return "https://8080-4417b0ad-e7ff-4d2f-acc8-c9ddcf7b56d9.us-west1.cloudshell.dev/oauth2callback";
+  }
 
-  //   public static GoogleAuthorizationCodeFlow newFlow() throws IOException {
-  //     return new GoogleAuthorizationCodeFlow.Builder(
-  //             new NetHttpTransport(),
-  //             JSON_FACTORY,
-  //             getClientCredential(),
-  //             Collections.singleton(CalendarScopes.CALENDAR))
-  //         .setDataStoreFactory(AppEngineDataStoreFactory.getDefaultInstance())
-  //         .setAccessType("offline")
-  //         .build();
-  //   }
+  public static GoogleAuthorizationCodeFlow newFlow() throws IOException {
+    return new GoogleAuthorizationCodeFlow.Builder(
+            HTTP_TRANSPORT,
+            JSON_FACTORY,
+            getClientCredential(),
+            Collections.singleton(CalendarScopes.CALENDAR))
+        .setDataStoreFactory(AppEngineDataStoreFactory.getDefaultInstance())
+        .setAccessType("offline")
+        .build();
+  }
 
-  //   public static Calendar loadCalendarClient() throws IOException {
-  //     String userId = UserServiceFactory.getUserService().getCurrentUser().getUserId();
-  //     Credential credential = newFlow().loadCredential(userId);
-  //     return new Calendar.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential).build();
-  //   }
+  static GoogleClientSecrets getClientCredential() throws IOException {
+    GoogleClientSecrets clientSecrets =
+        GoogleClientSecrets.load(
+            JSON_FACTORY,
+            new InputStreamReader(ServletUtil.class.getResourceAsStream("/client_secrets.json")));
+    return clientSecrets;
+  }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
+++ b/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
@@ -1,5 +1,10 @@
 package com.google.sps.servlets;
 
+import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
@@ -9,6 +14,10 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 
 public final class ServletUtil {
+  static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+  static final HttpTransport HTTP_TRANSPORT = new UrlFetchTransport();
+  private static GoogleClientSecrets clientSecrets = null;
+
   public static ImmutableList<String> getPropertyList(Entity entity, String property) {
     if (entity.getProperty(property) != null) {
       return ImmutableList.copyOf((ArrayList<String>) entity.getProperty(property));
@@ -26,4 +35,33 @@ public final class ServletUtil {
     }
     return entity.getProperty(Constants.PROPERTY_NAME).toString();
   }
+
+  //   // Loads client secrets from a stored file
+  //   public static GoogleClientSecrets getClientCredential() throws IOException {
+  //     if (clientSecrets == null) {
+  //       clientSecrets =
+  //           GoogleClientSecrets.load(
+  //               JSON_FACTORY,
+  //               new
+  // InputStreamReader(ServletUtil.class.getResourceAsStream("/client_secrets.json")));
+  //     }
+  //     return clientSecrets;
+  //   }
+
+  //   public static GoogleAuthorizationCodeFlow newFlow() throws IOException {
+  //     return new GoogleAuthorizationCodeFlow.Builder(
+  //             new NetHttpTransport(),
+  //             JSON_FACTORY,
+  //             getClientCredential(),
+  //             Collections.singleton(CalendarScopes.CALENDAR))
+  //         .setDataStoreFactory(AppEngineDataStoreFactory.getDefaultInstance())
+  //         .setAccessType("offline")
+  //         .build();
+  //   }
+
+  //   public static Calendar loadCalendarClient() throws IOException {
+  //     String userId = UserServiceFactory.getUserService().getCurrentUser().getUserId();
+  //     Credential credential = newFlow().loadCredential(userId);
+  //     return new Calendar.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential).build();
+  //   }
 }

--- a/capstone/src/main/resources/client_secrets.json
+++ b/capstone/src/main/resources/client_secrets.json
@@ -1,6 +1,0 @@
-{
-  "web": {
-    "client_id": "264953829929-ffv5q12afu4a7bm3vd7pnlfg8d96tlom.apps.googleusercontent.com",
-    "client_secret": "-g4ch6SGO-gu5CCpoY6pQ9qH"
-  }
-}

--- a/capstone/src/main/resources/client_secrets.json
+++ b/capstone/src/main/resources/client_secrets.json
@@ -1,0 +1,6 @@
+{
+  "web": {
+    "client_id": "264953829929-ffv5q12afu4a7bm3vd7pnlfg8d96tlom.apps.googleusercontent.com",
+    "client_secret": "-g4ch6SGO-gu5CCpoY6pQ9qH"
+  }
+}

--- a/capstone/src/main/webapp/about-us.html
+++ b/capstone/src/main/webapp/about-us.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta name="google-signin-client_id" content="264953829929-ffv5q12afu4a7bm3vd7pnlfg8d96tlom.apps.googleusercontent.com" charset="UTF-8">
     <title>Club Info</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">   

--- a/capstone/src/main/webapp/about-us.html
+++ b/capstone/src/main/webapp/about-us.html
@@ -89,7 +89,7 @@
       </div>
     </template>
     <template id="calendar">
-      <iframe id="calendar-element"></iframe>
+      <iframe id="calendar-element" title="Club Calendar"></iframe>
     </template>
   </body>
 </html>

--- a/capstone/src/main/webapp/club-registration.html
+++ b/capstone/src/main/webapp/club-registration.html
@@ -9,7 +9,7 @@
   <body>
     <div id="navbar"></div>
     <h2>Club Registration</h2>
-    <form id="club-form" action="/clubs" class="full-screen-panel" method="POST">
+    <form id="club-form" action="/clubs?response_mode=form_post" class="full-screen-panel" method="POST">
       <div class="form-group">
         <label for="name">Name:</label>
         <input type="text" name="name" id="club-name">

--- a/capstone/src/main/webapp/club-registration.html
+++ b/capstone/src/main/webapp/club-registration.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="UTF-8">
+    <meta name="google-signin-client_id" content="264953829929-ffv5q12afu4a7bm3vd7pnlfg8d96tlom.apps.googleusercontent.com" charset="UTF-8">
     <title>Club Registration</title>
     <link rel="stylesheet" href="style.css">
     <script src="script.js"></script>

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -38,7 +38,7 @@ async function getClubInfo() {
     }
     document.getElementById('club-logo-small').src = imageUrl;
     document.getElementById('club-name').innerHTML = clubInfo['name'];
-    document.getElementById('description').innerHTML = clubInfo['description'] + clubInfo['calendar'];
+    document.getElementById('description').innerHTML = clubInfo['description'];
     var officerList = document.getElementById('officers-list');
     var officers = clubInfo['officers'];
     for (const officer of officers) {
@@ -151,11 +151,7 @@ async function loadCalendar () {
   var params = new URLSearchParams(window.location.search);
   const response = await fetch('/clubs?name=' + params.get('name'));
   const json = await response.json();
-  if (json['officers'].length == 0) {
-    return; //Should never get here, as all clubs must have at least one officer. 
-  }
-  const firstOfficer = json['officers'][0];
-  document.getElementById('calendar-element').src = "https://calendar.google.com/calendar/embed?src=" + firstOfficer;
+  document.getElementById('calendar-element').src = "https://calendar.google.com/calendar/embed?src=" + json['calendar'];
 }
 
 /** Displays a certain tab for a club, by first checking for a GET parameter 

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -38,7 +38,7 @@ async function getClubInfo() {
     }
     document.getElementById('club-logo-small').src = imageUrl;
     document.getElementById('club-name').innerHTML = clubInfo['name'];
-    document.getElementById('description').innerHTML = clubInfo['description'];
+    document.getElementById('description').innerHTML = clubInfo['description'] + clubInfo['calendar'];
     var officerList = document.getElementById('officers-list');
     var officers = clubInfo['officers'];
     for (const officer of officers) {

--- a/capstone/src/main/webapp/script.js
+++ b/capstone/src/main/webapp/script.js
@@ -151,7 +151,11 @@ async function loadCalendar () {
   var params = new URLSearchParams(window.location.search);
   const response = await fetch('/clubs?name=' + params.get('name'));
   const json = await response.json();
-  document.getElementById('calendar-element').src = "https://calendar.google.com/calendar/embed?src=" + json['calendar'];
+
+  // Check that calendar ID exists before updating iframe
+  if (json['calendar'].length != 0) {
+    document.getElementById('calendar-element').src = "https://calendar.google.com/calendar/embed?src=" + json['calendar'];
+  }
 }
 
 /** Displays a certain tab for a club, by first checking for a GET parameter 

--- a/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
@@ -105,6 +105,7 @@ public final class ExploreServletTest {
     club1.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_1);
     club1.setProperty(Constants.WEBSITE_PROP, SITE_1);
     club1.setProperty(Constants.LOGO_PROP, BLOB_KEY_1);
+    club1.setProperty("calendar", "hi there");
     club1.setProperty(Constants.TIME_PROP, TIME_1);
 
     Entity club2 = new Entity(Constants.CLUB_ENTITY_PROP);
@@ -114,6 +115,7 @@ public final class ExploreServletTest {
     club2.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_2);
     club2.setProperty(Constants.WEBSITE_PROP, SITE_2);
     club2.setProperty(Constants.LOGO_PROP, BLOB_KEY_2);
+    club2.setProperty("calendar", "hello there");
     club2.setProperty(Constants.TIME_PROP, TIME_2);
 
     this.datastore.put(club1);

--- a/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
@@ -92,6 +92,9 @@ public final class ExploreServletTest {
     String BLOB_KEY_1 = "fake blob key";
     String BLOB_KEY_2 = "another fake blob key";
 
+    String CALENDAR_ID_1 = "calendar 1";
+    String CALENDAR_ID_2 = "calendar 2";
+
     long TIME_1 = 10;
     long TIME_2 = 20;
 
@@ -105,7 +108,7 @@ public final class ExploreServletTest {
     club1.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_1);
     club1.setProperty(Constants.WEBSITE_PROP, SITE_1);
     club1.setProperty(Constants.LOGO_PROP, BLOB_KEY_1);
-    club1.setProperty("calendar", "hi there");
+    club1.setProperty(Constants.CALENDAR_PROP, CALENDAR_ID_1);
     club1.setProperty(Constants.TIME_PROP, TIME_1);
 
     Entity club2 = new Entity(Constants.CLUB_ENTITY_PROP);
@@ -115,7 +118,7 @@ public final class ExploreServletTest {
     club2.setProperty(Constants.DESCRIP_PROP, DESCRIPTION_2);
     club2.setProperty(Constants.WEBSITE_PROP, SITE_2);
     club2.setProperty(Constants.LOGO_PROP, BLOB_KEY_2);
-    club2.setProperty("calendar", "hello there");
+    club2.setProperty(Constants.CALENDAR_PROP, CALENDAR_ID_2);
     club2.setProperty(Constants.TIME_PROP, TIME_2);
 
     this.datastore.put(club1);
@@ -145,6 +148,7 @@ public final class ExploreServletTest {
     Assert.assertEquals(object0.get(Constants.DESCRIP_PROP).getAsString(), DESCRIPTION_1);
     Assert.assertEquals(object0.get(Constants.WEBSITE_PROP).getAsString(), SITE_1);
     Assert.assertEquals(object0.get(Constants.LOGO_PROP).getAsString(), BLOB_KEY_1);
+    Assert.assertEquals(object0.get(Constants.CALENDAR_PROP).getAsString(), CALENDAR_ID_1);
     Assert.assertEquals(object0.get(Constants.TIME_PROP).getAsLong(), TIME_1);
 
     JsonElement element1 = response.get(1);
@@ -166,6 +170,7 @@ public final class ExploreServletTest {
     Assert.assertEquals(object1.get(Constants.DESCRIP_PROP).getAsString(), DESCRIPTION_2);
     Assert.assertEquals(object1.get(Constants.WEBSITE_PROP).getAsString(), SITE_2);
     Assert.assertEquals(object1.get(Constants.LOGO_PROP).getAsString(), BLOB_KEY_2);
+    Assert.assertEquals(object1.get(Constants.CALENDAR_PROP).getAsString(), CALENDAR_ID_2);
     Assert.assertEquals(object1.get(Constants.TIME_PROP).getAsLong(), TIME_2);
   }
 

--- a/capstone/src/test/java/com/google/sps/servlets/clubs/ClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/clubs/ClubServletTest.java
@@ -3,10 +3,16 @@ package com.google.sps.servlets;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.mockito.Mockito.when;
 
+import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.Calendar.Calendars;
+import com.google.api.services.calendar.Calendar.Calendars.Insert;
 import com.google.appengine.api.blobstore.BlobstoreService;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.tools.development.testing.LocalBlobstoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
@@ -40,12 +46,17 @@ public class ClubServletTest {
   private final String SAMPLE_CLUB_WEB = "www.test-club.com";
   private final String SAMPLE_BLOB = "test-blobkey";
   private final String TEST_EMAIL = "test-email@gmail.com";
+  private final String SAMPLE_CAL_ID = "Club 1 Calendar ID";
   private final long SAMPLE_TIME = 25;
   private final ImmutableList<String> STUDENT_LIST = ImmutableList.of(TEST_EMAIL);
 
-  @Mock private HttpServletRequest request;
-  @Mock private HttpServletResponse response;
+  @Mock HttpServletRequest request;
+  @Mock HttpServletResponse response;
   @Mock Principal principal;
+  @Mock Calendar calendarService;
+  @Mock Calendars mockCalendar;
+  @Mock Insert calendarInsert;
+  @Mock com.google.api.services.calendar.model.Calendar modelCalendar;
   private BlobstoreService blobstore;
   private ClubServlet clubServlet;
   private DatastoreService datastore;
@@ -74,8 +85,9 @@ public class ClubServletTest {
   public void doPost_registerNewValidClub() throws ServletException, IOException {
     when(request.getUserPrincipal()).thenReturn(principal);
     when(principal.getName()).thenReturn("test-email@gmail.com");
+
     doPost_helper();
-    clubServlet.doPostHelper(request, response, datastore);
+    clubServlet.doPostHelper(request, response, datastore, calendarService);
 
     Query query =
         new Query(Constants.CLUB_ENTITY_PROP)
@@ -91,6 +103,7 @@ public class ClubServletTest {
     Assert.assertEquals(SAMPLE_CLUB_WEB, clubEntity.getProperty(Constants.WEBSITE_PROP));
     Assert.assertEquals(STUDENT_LIST, clubEntity.getProperty(Constants.MEMBER_PROP));
     Assert.assertEquals(STUDENT_LIST, clubEntity.getProperty(Constants.OFFICER_PROP));
+    Assert.assertEquals(SAMPLE_CAL_ID, clubEntity.getProperty(Constants.CALENDAR_PROP));
 
     Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=true");
   }
@@ -99,11 +112,13 @@ public class ClubServletTest {
   public void doPost_registerNewInvalidClub() throws ServletException, IOException {
     when(request.getUserPrincipal()).thenReturn(principal);
     when(principal.getName()).thenReturn("officer@example.com");
+    // when(calendarService.calendars().insert(calendar).execute().getId()).thenReturn("calendar
+    // ID");
     doPost_helper();
-    clubServlet.doPostHelper(request, response, datastore);
+    clubServlet.doPostHelper(request, response, datastore, calendarService);
 
     when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn("club desc");
-    clubServlet.doPostHelper(request, response, datastore);
+    clubServlet.doPostHelper(request, response, datastore, calendarService);
 
     Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=false");
     Query query =
@@ -134,7 +149,7 @@ public class ClubServletTest {
     clubEntity.setProperty(Constants.OFFICER_PROP, expectedOfficers);
     clubEntity.setProperty(Constants.WEBSITE_PROP, "website.com");
     clubEntity.setProperty(Constants.LOGO_PROP, SAMPLE_BLOB);
-    clubEntity.setProperty("calendar", "calendar ID");
+    clubEntity.setProperty(Constants.CALENDAR_PROP, SAMPLE_CAL_ID);
     clubEntity.setProperty(Constants.TIME_PROP, SAMPLE_TIME);
     datastore.put(clubEntity);
 
@@ -155,7 +170,7 @@ public class ClubServletTest {
     Assert.assertEquals(expectedMembers, actualMembers);
     Assert.assertEquals(expectedOfficers, actualOfficers);
     Assert.assertEquals("website.com", response.get(Constants.WEBSITE_PROP).getAsString());
-    Assert.assertEquals("calendar ID", response.get("calendar").getAsString());
+    Assert.assertEquals(SAMPLE_CAL_ID, response.get("calendar").getAsString());
     Assert.assertEquals(SAMPLE_TIME, response.get(Constants.TIME_PROP).getAsLong());
   }
 
@@ -177,10 +192,20 @@ public class ClubServletTest {
     return converted;
   }
 
-  private void doPost_helper() {
+  private void doPost_helper() throws IOException {
     helper.setEnvEmail(TEST_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
     when(request.getParameter(Constants.PROPERTY_NAME)).thenReturn(SAMPLE_CLUB_NAME);
     when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn(SAMPLE_CLUB_DESC_1);
     when(request.getParameter(Constants.WEBSITE_PROP)).thenReturn(SAMPLE_CLUB_WEB);
+
+    com.google.api.services.calendar.model.Calendar calendar =
+        new com.google.api.services.calendar.model.Calendar()
+            .setSummary(SAMPLE_CLUB_NAME + " Calendar")
+            .setTimeZone("America/Los_Angeles");
+
+    when(calendarService.calendars()).thenReturn(mockCalendar);
+    when(mockCalendar.insert(calendar)).thenReturn(calendarInsert);
+    when(calendarInsert.execute()).thenReturn(modelCalendar);
+    when(modelCalendar.getId()).thenReturn(SAMPLE_CAL_ID);
   }
 }

--- a/capstone/src/test/java/com/google/sps/servlets/clubs/ClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/clubs/ClubServletTest.java
@@ -112,8 +112,6 @@ public class ClubServletTest {
   public void doPost_registerNewInvalidClub() throws ServletException, IOException {
     when(request.getUserPrincipal()).thenReturn(principal);
     when(principal.getName()).thenReturn("officer@example.com");
-    // when(calendarService.calendars().insert(calendar).execute().getId()).thenReturn("calendar
-    // ID");
     doPost_helper();
     clubServlet.doPostHelper(request, response, datastore, calendarService);
 
@@ -170,7 +168,7 @@ public class ClubServletTest {
     Assert.assertEquals(expectedMembers, actualMembers);
     Assert.assertEquals(expectedOfficers, actualOfficers);
     Assert.assertEquals("website.com", response.get(Constants.WEBSITE_PROP).getAsString());
-    Assert.assertEquals(SAMPLE_CAL_ID, response.get("calendar").getAsString());
+    Assert.assertEquals(SAMPLE_CAL_ID, response.get(Constants.CALENDAR_PROP).getAsString());
     Assert.assertEquals(SAMPLE_TIME, response.get(Constants.TIME_PROP).getAsLong());
   }
 

--- a/capstone/src/test/java/com/google/sps/servlets/clubs/ClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/clubs/ClubServletTest.java
@@ -7,9 +7,6 @@ import com.google.appengine.api.blobstore.BlobstoreService;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.Query;
-import com.google.appengine.api.datastore.Query.FilterOperator;
-import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.tools.development.testing.LocalBlobstoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
@@ -73,52 +70,52 @@ public class ClubServletTest {
     helper.tearDown();
   }
 
-  @Test
-  public void doPost_registerNewValidClub() throws ServletException, IOException {
-    when(request.getUserPrincipal()).thenReturn(principal);
-    when(principal.getName()).thenReturn("test-email@gmail.com");
-    doPost_helper();
-    clubServlet.doPostHelper(request, response, datastore);
+  //   @Test
+  //   public void doPost_registerNewValidClub() throws ServletException, IOException {
+  //     when(request.getUserPrincipal()).thenReturn(principal);
+  //     when(principal.getName()).thenReturn("test-email@gmail.com");
+  //     doPost_helper();
+  //     clubServlet.doPostHelper(request, response, datastore);
 
-    Query query =
-        new Query(Constants.CLUB_ENTITY_PROP)
-            .setFilter(
-                new FilterPredicate(
-                    Constants.PROPERTY_NAME,
-                    FilterOperator.EQUAL,
-                    request.getParameter(Constants.PROPERTY_NAME)));
-    Entity clubEntity = datastore.prepare(query).asSingleEntity();
+  //     Query query =
+  //         new Query(Constants.CLUB_ENTITY_PROP)
+  //             .setFilter(
+  //                 new FilterPredicate(
+  //                     Constants.PROPERTY_NAME,
+  //                     FilterOperator.EQUAL,
+  //                     request.getParameter(Constants.PROPERTY_NAME)));
+  //     Entity clubEntity = datastore.prepare(query).asSingleEntity();
 
-    Assert.assertEquals(SAMPLE_CLUB_NAME, clubEntity.getProperty(Constants.PROPERTY_NAME));
-    Assert.assertEquals(SAMPLE_CLUB_DESC_1, clubEntity.getProperty(Constants.DESCRIP_PROP));
-    Assert.assertEquals(SAMPLE_CLUB_WEB, clubEntity.getProperty(Constants.WEBSITE_PROP));
-    Assert.assertEquals(STUDENT_LIST, clubEntity.getProperty(Constants.MEMBER_PROP));
-    Assert.assertEquals(STUDENT_LIST, clubEntity.getProperty(Constants.OFFICER_PROP));
+  //     Assert.assertEquals(SAMPLE_CLUB_NAME, clubEntity.getProperty(Constants.PROPERTY_NAME));
+  //     Assert.assertEquals(SAMPLE_CLUB_DESC_1, clubEntity.getProperty(Constants.DESCRIP_PROP));
+  //     Assert.assertEquals(SAMPLE_CLUB_WEB, clubEntity.getProperty(Constants.WEBSITE_PROP));
+  //     Assert.assertEquals(STUDENT_LIST, clubEntity.getProperty(Constants.MEMBER_PROP));
+  //     Assert.assertEquals(STUDENT_LIST, clubEntity.getProperty(Constants.OFFICER_PROP));
 
-    Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=true");
-  }
+  //     Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=true");
+  //   }
 
-  @Test
-  public void doPost_registerNewInvalidClub() throws ServletException, IOException {
-    when(request.getUserPrincipal()).thenReturn(principal);
-    when(principal.getName()).thenReturn("officer@example.com");
-    doPost_helper();
-    clubServlet.doPostHelper(request, response, datastore);
+  //   @Test
+  //   public void doPost_registerNewInvalidClub() throws ServletException, IOException {
+  //     when(request.getUserPrincipal()).thenReturn(principal);
+  //     when(principal.getName()).thenReturn("officer@example.com");
+  //     doPost_helper();
+  //     clubServlet.doPostHelper(request, response, datastore);
 
-    when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn("club desc");
-    clubServlet.doPostHelper(request, response, datastore);
+  //     when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn("club desc");
+  //     clubServlet.doPostHelper(request, response, datastore);
 
-    Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=false");
-    Query query =
-        new Query("Club")
-            .setFilter(
-                new FilterPredicate(
-                    Constants.PROPERTY_NAME,
-                    FilterOperator.EQUAL,
-                    request.getParameter(Constants.PROPERTY_NAME)));
-    Entity clubEntity = datastore.prepare(query).asSingleEntity();
-    Assert.assertEquals(SAMPLE_CLUB_DESC_1, clubEntity.getProperty(Constants.DESCRIP_PROP));
-  }
+  //     Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=false");
+  //     Query query =
+  //         new Query("Club")
+  //             .setFilter(
+  //                 new FilterPredicate(
+  //                     Constants.PROPERTY_NAME,
+  //                     FilterOperator.EQUAL,
+  //                     request.getParameter(Constants.PROPERTY_NAME)));
+  //     Entity clubEntity = datastore.prepare(query).asSingleEntity();
+  //     Assert.assertEquals(SAMPLE_CLUB_DESC_1, clubEntity.getProperty(Constants.DESCRIP_PROP));
+  //   }
 
   @Test
   public void doGet_clubExists() throws ServletException, IOException {
@@ -137,6 +134,7 @@ public class ClubServletTest {
     clubEntity.setProperty(Constants.OFFICER_PROP, expectedOfficers);
     clubEntity.setProperty(Constants.WEBSITE_PROP, "website.com");
     clubEntity.setProperty(Constants.LOGO_PROP, SAMPLE_BLOB);
+    clubEntity.setProperty("calendar", "calendar ID");
     clubEntity.setProperty(Constants.TIME_PROP, SAMPLE_TIME);
     datastore.put(clubEntity);
 
@@ -157,6 +155,7 @@ public class ClubServletTest {
     Assert.assertEquals(expectedMembers, actualMembers);
     Assert.assertEquals(expectedOfficers, actualOfficers);
     Assert.assertEquals("website.com", response.get(Constants.WEBSITE_PROP).getAsString());
+    Assert.assertEquals("calendar ID", response.get("calendar").getAsString());
     Assert.assertEquals(SAMPLE_TIME, response.get(Constants.TIME_PROP).getAsLong());
   }
 

--- a/capstone/src/test/java/com/google/sps/servlets/clubs/ClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/clubs/ClubServletTest.java
@@ -70,52 +70,52 @@ public class ClubServletTest {
     helper.tearDown();
   }
 
-  //   @Test
-  //   public void doPost_registerNewValidClub() throws ServletException, IOException {
-  //     when(request.getUserPrincipal()).thenReturn(principal);
-  //     when(principal.getName()).thenReturn("test-email@gmail.com");
-  //     doPost_helper();
-  //     clubServlet.doPostHelper(request, response, datastore);
+  @Test
+  public void doPost_registerNewValidClub() throws ServletException, IOException {
+    when(request.getUserPrincipal()).thenReturn(principal);
+    when(principal.getName()).thenReturn("test-email@gmail.com");
+    doPost_helper();
+    clubServlet.doPostHelper(request, response, datastore);
 
-  //     Query query =
-  //         new Query(Constants.CLUB_ENTITY_PROP)
-  //             .setFilter(
-  //                 new FilterPredicate(
-  //                     Constants.PROPERTY_NAME,
-  //                     FilterOperator.EQUAL,
-  //                     request.getParameter(Constants.PROPERTY_NAME)));
-  //     Entity clubEntity = datastore.prepare(query).asSingleEntity();
+    Query query =
+        new Query(Constants.CLUB_ENTITY_PROP)
+            .setFilter(
+                new FilterPredicate(
+                    Constants.PROPERTY_NAME,
+                    FilterOperator.EQUAL,
+                    request.getParameter(Constants.PROPERTY_NAME)));
+    Entity clubEntity = datastore.prepare(query).asSingleEntity();
 
-  //     Assert.assertEquals(SAMPLE_CLUB_NAME, clubEntity.getProperty(Constants.PROPERTY_NAME));
-  //     Assert.assertEquals(SAMPLE_CLUB_DESC_1, clubEntity.getProperty(Constants.DESCRIP_PROP));
-  //     Assert.assertEquals(SAMPLE_CLUB_WEB, clubEntity.getProperty(Constants.WEBSITE_PROP));
-  //     Assert.assertEquals(STUDENT_LIST, clubEntity.getProperty(Constants.MEMBER_PROP));
-  //     Assert.assertEquals(STUDENT_LIST, clubEntity.getProperty(Constants.OFFICER_PROP));
+    Assert.assertEquals(SAMPLE_CLUB_NAME, clubEntity.getProperty(Constants.PROPERTY_NAME));
+    Assert.assertEquals(SAMPLE_CLUB_DESC_1, clubEntity.getProperty(Constants.DESCRIP_PROP));
+    Assert.assertEquals(SAMPLE_CLUB_WEB, clubEntity.getProperty(Constants.WEBSITE_PROP));
+    Assert.assertEquals(STUDENT_LIST, clubEntity.getProperty(Constants.MEMBER_PROP));
+    Assert.assertEquals(STUDENT_LIST, clubEntity.getProperty(Constants.OFFICER_PROP));
 
-  //     Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=true");
-  //   }
+    Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=true");
+  }
 
-  //   @Test
-  //   public void doPost_registerNewInvalidClub() throws ServletException, IOException {
-  //     when(request.getUserPrincipal()).thenReturn(principal);
-  //     when(principal.getName()).thenReturn("officer@example.com");
-  //     doPost_helper();
-  //     clubServlet.doPostHelper(request, response, datastore);
+  @Test
+  public void doPost_registerNewInvalidClub() throws ServletException, IOException {
+    when(request.getUserPrincipal()).thenReturn(principal);
+    when(principal.getName()).thenReturn("officer@example.com");
+    doPost_helper();
+    clubServlet.doPostHelper(request, response, datastore);
 
-  //     when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn("club desc");
-  //     clubServlet.doPostHelper(request, response, datastore);
+    when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn("club desc");
+    clubServlet.doPostHelper(request, response, datastore);
 
-  //     Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=false");
-  //     Query query =
-  //         new Query("Club")
-  //             .setFilter(
-  //                 new FilterPredicate(
-  //                     Constants.PROPERTY_NAME,
-  //                     FilterOperator.EQUAL,
-  //                     request.getParameter(Constants.PROPERTY_NAME)));
-  //     Entity clubEntity = datastore.prepare(query).asSingleEntity();
-  //     Assert.assertEquals(SAMPLE_CLUB_DESC_1, clubEntity.getProperty(Constants.DESCRIP_PROP));
-  //   }
+    Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=false");
+    Query query =
+        new Query("Club")
+            .setFilter(
+                new FilterPredicate(
+                    Constants.PROPERTY_NAME,
+                    FilterOperator.EQUAL,
+                    request.getParameter(Constants.PROPERTY_NAME)));
+    Entity clubEntity = datastore.prepare(query).asSingleEntity();
+    Assert.assertEquals(SAMPLE_CLUB_DESC_1, clubEntity.getProperty(Constants.DESCRIP_PROP));
+  }
 
   @Test
   public void doGet_clubExists() throws ServletException, IOException {

--- a/capstone/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/capstone/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Creates OAuth callback servlet to get user permissions for Calendar API on dashboard (explore page) so that it may be used for calendar creation, update, and permissions changes. Updates club registration form to create a Calendar under current user's email. The corresponding calendar ID is stored in Datastore, then used to display the calendar on the club info page. Updates club registration tests accordingly. Update relevant servlets to also rely on OAuth, since user must be signed in to have access. Add file to allow for Mocks of final classes.