### PR TITLE
Move reused helper method to ServletUtil and add tests

### DIFF
--- a/capstone/src/main/java/com/google/sps/servlets/student/InterestedClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/InterestedClubServlet.java
@@ -9,8 +9,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -52,7 +50,10 @@ public class InterestedClubServlet extends HttpServlet {
     String interestedClubToJoin = request.getParameter(Constants.INTERESTED_JOIN_PROP);
     if (!Strings.isNullOrEmpty(interestedClubToJoin)) {
       // Update Datastore with edited student entity
-      addItemToEntity(student, datastore, interestedClubToJoin, Constants.INTERESTED_CLUB_PROP);
+      student =
+          ServletUtil.addItemToEntity(
+              student, interestedClubToJoin, Constants.INTERESTED_CLUB_PROP);
+      datastore.put(student);
     }
     response.sendRedirect("/explore.html");
   }
@@ -69,17 +70,5 @@ public class InterestedClubServlet extends HttpServlet {
     }
     // A user can only be logged in with one email address at a time
     return students.get(0);
-  }
-
-  private static void addItemToEntity(
-      Entity entity, DatastoreService datastore, String itemToAdd, String property) {
-    // Create empty List if property does not exist yet
-    List<String> generalList = new ArrayList<String>(ServletUtil.getPropertyList(entity, property));
-    if (!generalList.contains(itemToAdd)) {
-      generalList.add(itemToAdd);
-    }
-    // Add updated entity to Datastore
-    entity.setProperty(property, generalList);
-    datastore.put(entity);
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
@@ -226,26 +226,6 @@ public class StudentServlet extends HttpServlet {
     }
     return clubs.get(0);
   }
-
-  //   private static void addOrRemoveItemToEntity(
-  //       Entity entity,
-  //       DatastoreService datastore,
-  //       String itemToAddOrRemove,
-  //       String property,
-  //       Boolean addItem) {
-  //     // Create empty List if property does not exist yet
-  //     List<String> generalList = new ArrayList<String>(ServletUtil.getPropertyList(entity,
-  // property));
-  //     if (addItem && !generalList.contains(itemToAddOrRemove)) {
-  //       generalList.add(itemToAddOrRemove);
-  //     }
-  //     if (!addItem && generalList.contains(itemToAddOrRemove)) {
-  //       generalList.remove(itemToAddOrRemove);
-  //     }
-  //     // Add updated entity to Datastore
-  //     entity.setProperty(property, generalList);
-  //     datastore.put(entity);
-  //   }
 }
 
 class StudentInfo {

--- a/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/StudentServlet.java
@@ -18,7 +18,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.List;
 import java.util.TimeZone;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -94,10 +93,12 @@ public class StudentServlet extends HttpServlet {
       if (club == null) {
         return;
       }
-      addOrRemoveItemToEntity(club, datastore, userEmail, Constants.MEMBER_PROP, true);
+      club = ServletUtil.addItemToEntity(club, userEmail, Constants.MEMBER_PROP);
+      datastore.put(club);
 
       // Add new club to student's club list and update Datastore
-      addOrRemoveItemToEntity(student, datastore, clubToJoin, Constants.PROPERTY_CLUBS, true);
+      student = ServletUtil.addItemToEntity(student, clubToJoin, Constants.PROPERTY_CLUBS);
+      datastore.put(student);
       response.sendRedirect("/about-us.html?name=" + club.getProperty(Constants.PROPERTY_NAME));
     } else if (clubToRemove != null && !clubToRemove.isEmpty()) {
       // Remove member from club's member list and update Datastore
@@ -105,11 +106,13 @@ public class StudentServlet extends HttpServlet {
       if (club == null) {
         return;
       }
-      addOrRemoveItemToEntity(club, datastore, userEmail, Constants.MEMBER_PROP, false);
-      addOrRemoveItemToEntity(club, datastore, userEmail, Constants.OFFICER_PROP, false);
+      club = ServletUtil.removeItemFromEntity(club, userEmail, Constants.MEMBER_PROP);
+      club = ServletUtil.removeItemFromEntity(club, userEmail, Constants.OFFICER_PROP);
+      datastore.put(club);
 
       // Remove club from student's club list and update Datastore
-      addOrRemoveItemToEntity(student, datastore, clubToRemove, Constants.PROPERTY_CLUBS, false);
+      student = ServletUtil.removeItemFromEntity(student, clubToRemove, Constants.PROPERTY_CLUBS);
+      datastore.put(student);
       response.sendRedirect("/profile.html");
     } else {
       response.sendRedirect("/profile.html");
@@ -224,24 +227,25 @@ public class StudentServlet extends HttpServlet {
     return clubs.get(0);
   }
 
-  private static void addOrRemoveItemToEntity(
-      Entity entity,
-      DatastoreService datastore,
-      String itemToAddOrRemove,
-      String property,
-      Boolean addItem) {
-    // Create empty List if property does not exist yet
-    List<String> generalList = new ArrayList<String>(ServletUtil.getPropertyList(entity, property));
-    if (addItem && !generalList.contains(itemToAddOrRemove)) {
-      generalList.add(itemToAddOrRemove);
-    }
-    if (!addItem && generalList.contains(itemToAddOrRemove)) {
-      generalList.remove(itemToAddOrRemove);
-    }
-    // Add updated entity to Datastore
-    entity.setProperty(property, generalList);
-    datastore.put(entity);
-  }
+  //   private static void addOrRemoveItemToEntity(
+  //       Entity entity,
+  //       DatastoreService datastore,
+  //       String itemToAddOrRemove,
+  //       String property,
+  //       Boolean addItem) {
+  //     // Create empty List if property does not exist yet
+  //     List<String> generalList = new ArrayList<String>(ServletUtil.getPropertyList(entity,
+  // property));
+  //     if (addItem && !generalList.contains(itemToAddOrRemove)) {
+  //       generalList.add(itemToAddOrRemove);
+  //     }
+  //     if (!addItem && generalList.contains(itemToAddOrRemove)) {
+  //       generalList.remove(itemToAddOrRemove);
+  //     }
+  //     // Add updated entity to Datastore
+  //     entity.setProperty(property, generalList);
+  //     datastore.put(entity);
+  //   }
 }
 
 class StudentInfo {

--- a/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
+++ b/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
@@ -7,6 +7,7 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.List;
 
 public final class ServletUtil {
   public static ImmutableList<String> getPropertyList(Entity entity, String property) {
@@ -25,5 +26,27 @@ public final class ServletUtil {
       return null;
     }
     return entity.getProperty(Constants.PROPERTY_NAME).toString();
+  }
+
+  public static Entity addItemToEntity(Entity entity, String itemToAdd, String property) {
+    // Create empty List if property does not exist yet
+    List<String> generalList = new ArrayList<String>(ServletUtil.getPropertyList(entity, property));
+    if (!generalList.contains(itemToAdd)) {
+      generalList.add(itemToAdd);
+    }
+    // Add updated entity to Datastore
+    entity.setProperty(property, generalList);
+    return entity;
+  }
+
+  public static Entity removeItemFromEntity(Entity entity, String itemToRemove, String property) {
+    // Create empty List if property does not exist yet
+    List<String> generalList = new ArrayList<String>(ServletUtil.getPropertyList(entity, property));
+    if (generalList.contains(itemToRemove)) {
+      generalList.remove(itemToRemove);
+    }
+    // Add updated entity to Datastore
+    entity.setProperty(property, generalList);
+    return entity;
   }
 }


### PR DESCRIPTION
This branch adds code to move the addItemToEntity and removeItemFromEntity helper methods to the ServletUtil class in order to be reused for the StudentServlet and the InterestedClubServlet. The helper methods have been changed so they only update the Entity object and not Datastore since the changes in Datastore must persist. Tests have also been added to ensure that the helper methods work correctly. 