### PR TITLE
Add "Leave" button for interested clubs

### DIFF
--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -10,6 +10,7 @@ public final class Constants {
   public static final String CLUB_PROP = "club";
   public static final String INTERESTED_CLUB_PROP = "interestedClubs";
   public static final String INTERESTED_JOIN_PROP = "interested-join";
+  public static final String INTERESTED_LEAVE_PROP = "interested-leave";
   public static final String PROPERTY_NAME = "name";
   public static final String PROPERTY_EMAIL = "email";
   public static final String PROPERTY_GRADYEAR = "gradYear";

--- a/capstone/src/main/java/com/google/sps/servlets/student/InterestedClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/InterestedClubServlet.java
@@ -54,8 +54,18 @@ public class InterestedClubServlet extends HttpServlet {
           ServletUtil.addItemToEntity(
               student, interestedClubToJoin, Constants.INTERESTED_CLUB_PROP);
       datastore.put(student);
+      response.sendRedirect("/explore.html");
     }
-    response.sendRedirect("/explore.html");
+    // Remove interested club if necessary
+    String interestedClubToLeave = request.getParameter("interested-leave");
+    if (!Strings.isNullOrEmpty(interestedClubToLeave)) {
+      // Update Datastore with edited student entity
+      student =
+          ServletUtil.removeItemFromEntity(
+              student, interestedClubToLeave, Constants.INTERESTED_CLUB_PROP);
+      datastore.put(student);
+      response.sendRedirect("/profile.html");
+    }
   }
 
   private Entity getStudent(String userEmail, DatastoreService datastore) throws IOException {

--- a/capstone/src/main/java/com/google/sps/servlets/student/InterestedClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/InterestedClubServlet.java
@@ -57,7 +57,7 @@ public class InterestedClubServlet extends HttpServlet {
       response.sendRedirect("/explore.html");
     }
     // Remove interested club if necessary
-    String interestedClubToLeave = request.getParameter("interested-leave");
+    String interestedClubToLeave = request.getParameter(Constants.INTERESTED_LEAVE_PROP);
     if (!Strings.isNullOrEmpty(interestedClubToLeave)) {
       // Update Datastore with edited student entity
       student =

--- a/capstone/src/main/webapp/profile-loader.js
+++ b/capstone/src/main/webapp/profile-loader.js
@@ -42,7 +42,9 @@ function displayElements(items, templateId, documentId) {
   const template = document.querySelector(templateId);
   for(const item of items){
     if (templateId == '#club-list') {
-      template.content.querySelector('li').innerHTML = getClubContent(item);
+      template.content.querySelector('li').innerHTML = getClubContent(item, 'leave');
+    } else if(templateId == '#interested-list') {
+      template.content.querySelector('li').innerHTML = getClubContent(item, 'interested-leave');
     } else {
       template.content.querySelector('li').innerHTML = item;
     }
@@ -51,9 +53,9 @@ function displayElements(items, templateId, documentId) {
   }
 }
 
-function getClubContent(club) {
-  const content = club + '  <button id="leave" name="leave" value="' + club + '" formmethod="POST">Leave</button>';
-  return content;
+function getClubContent(club, name) {
+  const content = club + '  <button id="leave" name="insert-name" value="' + club + '" formmethod="POST">Leave</button>';
+  return content.replace('insert-name', name);
 }
 
 /** Store edited content from profile page */

--- a/capstone/src/main/webapp/profile.html
+++ b/capstone/src/main/webapp/profile.html
@@ -26,11 +26,12 @@
         </form>
         <br>
         <h2>My Interested Clubs:</h2>
-        <ul id="interested-club-content">
-          <template id="interested-list">
-            <li></li>
-          </template>
-        </ul>
+        <form name="interested-leave" action="/interested-clubs" method="GET">
+          <ul id="interested-club-content">
+            <template id="interested-list">
+              <li></li>
+            </template>
+          </ul>
         </form>
         <br>
         <form name="edit-profile" action="/student-data" method="POST">

--- a/capstone/src/main/webapp/profile.html
+++ b/capstone/src/main/webapp/profile.html
@@ -34,21 +34,6 @@
           </ul>
         </form>
         <br>
-        <form name="edit-profile" action="/student-data" method="POST">
-          <div id="student-info">
-            <div id="email">Email: </div>
-            Grad Year: 
-            <div id="edit-year" class="edit-profile" contenteditable="true"></div>  <i class="far fa-edit"></i><br>
-            Major: 
-            <div id="edit-major" class="edit-profile" contenteditable="true"></div>  <i class="far fa-edit"></i>
-          </div><br>
-          <button class="save-button" name="edit-profile" onclick="saveProfileChanges()">Save Changes</button>
-          <div id="update-profile">
-            <input type="hidden" name="new-year" value="">
-            <input type="hidden" name="new-major" value="">
-            <input type="hidden" name="new-name" value="">
-          </div>
-        </form>
       </div>
       <div class="split-profile right-profile">
         <h1><u>Inbox</u></h1>
@@ -66,6 +51,21 @@
           <input hidden id="submit-picture" onchange="this.form.submit()" type="file" name="upload-profile">
         </form>
         <br><br>
+        <form name="edit-profile" action="/student-data" method="POST">
+          <div id="student-info">
+            <div id="email">Email: </div>
+            Grad Year: 
+            <div id="edit-year" class="edit-profile" contenteditable="true"></div>  <i class="far fa-edit"></i><br>
+            Major: 
+            <div id="edit-major" class="edit-profile" contenteditable="true"></div>  <i class="far fa-edit"></i>
+          </div><br>
+          <button class="save-button" name="edit-profile" onclick="saveProfileChanges()">Save Changes</button>
+          <div id="update-profile">
+            <input type="hidden" name="new-year" value="">
+            <input type="hidden" name="new-major" value="">
+            <input type="hidden" name="new-name" value="">
+          </div>
+        </form>
       </div>
     </div>
   </body>

--- a/capstone/src/main/webapp/style.css
+++ b/capstone/src/main/webapp/style.css
@@ -10,7 +10,8 @@ body {
 
 #profile-heading,
 #explore-heading,
-#login {
+#login,
+#student-info {
   text-align: center;
 }
 
@@ -29,11 +30,20 @@ p {
 
 .upload-profile-pic,
 .save-button,
-#login-button {
+#login-button,
+#student-info {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
   margin: 0;
+}
+
+.save-button {
+  margin-top: 5%;
+}
+
+#student-info {
+  margin-top: 1%;
 }
 
 button {

--- a/capstone/src/test/java/com/google/sps/servlets/student/InterestedClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/student/InterestedClubServletTest.java
@@ -130,9 +130,7 @@ public final class InterestedClubServletTest {
     PreparedQuery results = datastore.prepare(query);
     Entity student = results.asSingleEntity();
     Assert.assertTrue(student != null);
-    ImmutableList<String> interestedClubList =
-        ImmutableList.copyOf(
-            (ArrayList<String>) student.getProperty(Constants.INTERESTED_CLUB_PROP));
+    ImmutableList<String> interestedClubList = ServletUtil.getPropertyList(student, Constants.INTERESTED_CLUB_PROP));
     Assert.assertFalse(interestedClubList.isEmpty());
     String interestedClub = interestedClubList.get(0);
 
@@ -145,7 +143,7 @@ public final class InterestedClubServletTest {
   public void doPost_studentLeavesInterestedClub() throws ServletException, IOException {
     datastore.put(studentMegan);
     localHelper.setEnvEmail(MEGAN_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
-    when(request.getParameter("interested-leave")).thenReturn(CLUB_1);
+    when(request.getParameter(Constants.INTERESTED_LEAVE_PROP)).thenReturn(CLUB_1);
     when(request.getUserPrincipal()).thenReturn(principal);
     when(principal.getName()).thenReturn(MEGAN_EMAIL);
 

--- a/capstone/src/test/java/com/google/sps/servlets/student/InterestedClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/student/InterestedClubServletTest.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.security.Principal;
-import java.util.ArrayList;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -130,7 +129,8 @@ public final class InterestedClubServletTest {
     PreparedQuery results = datastore.prepare(query);
     Entity student = results.asSingleEntity();
     Assert.assertTrue(student != null);
-    ImmutableList<String> interestedClubList = ServletUtil.getPropertyList(student, Constants.INTERESTED_CLUB_PROP));
+    ImmutableList<String> interestedClubList =
+        ServletUtil.getPropertyList(student, Constants.INTERESTED_CLUB_PROP);
     Assert.assertFalse(interestedClubList.isEmpty());
     String interestedClub = interestedClubList.get(0);
 


### PR DESCRIPTION
This PR adds the "Leave" option for a student's interested club list. Once the user clicks "Leave," the club will be removed from their interested club list in Datastore and they will be redirected to the profile page. In addition, the personal information on the profile page has been centered to avoid having to scroll to see or edit one's main information (this may happen if the user were to have longer club / interested club lists).