### PR TITLE
Redirect user to correct page after logging in

### DIFF
--- a/capstone/src/main/java/com/google/sps/servlets/Constants.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Constants.java
@@ -56,4 +56,5 @@ public final class Constants {
   public static final String TIMEZONE_PROP = "timezone";
   public static final String EMAIL_PATH = "/emailTemplates/";
   public static final String SERVICE_PROP = "service";
+  public static final String DEFAULT = "default";
 }

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -33,7 +33,7 @@ public class ExploreServlet extends AbstractAppEngineAuthorizationCodeServlet {
 
     String sort =
         request.getParameter(Constants.SORT_PROP) == null
-            ? "default"
+            ? Constants.DEFAULT
             : request.getParameter(Constants.SORT_PROP);
     Comparator<Club> comparator = getComparator(sort);
 

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -14,6 +14,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import com.google.gson.Gson;
+import com.google.sps.gmail.EmailFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
@@ -31,11 +32,17 @@ public class ExploreServlet extends AbstractAppEngineAuthorizationCodeServlet {
     Gson gson = new Gson();
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-    String sort = request.getParameter(Constants.SORT_PROP);
+    String sort =
+        request.getParameter(Constants.SORT_PROP) == null
+            ? "default"
+            : request.getParameter(Constants.SORT_PROP);
     Comparator<Club> comparator = getComparator(sort);
 
-    ImmutableList<String> rawLabels =
-        ImmutableList.copyOf(request.getParameter(Constants.LABELS_PROP).split(","));
+    String rawLabelsStr =
+        request.getParameter(Constants.LABELS_PROP) == null
+            ? ""
+            : request.getParameter(Constants.LABELS_PROP);
+    ImmutableList<String> rawLabels = ImmutableList.copyOf(rawLabelsStr.split(","));
     ImmutableList<String> labels =
         rawLabels.stream()
             .filter(Predicates.not(Strings::isNullOrEmpty))
@@ -50,26 +57,17 @@ public class ExploreServlet extends AbstractAppEngineAuthorizationCodeServlet {
             .limit(Constants.LOAD_LIMIT)
             .collect(toImmutableList());
 
+    // Get or create student entity and store club lists
+    Entity student = StudentServlet.getStudent(request, userEmail, datastore);
     ImmutableList<String> studentClubs =
-        getStudentClubList(userEmail, Constants.PROPERTY_CLUBS, datastore);
+        ServletUtil.getPropertyList(student, Constants.PROPERTY_CLUBS);
     ImmutableList<String> interestedClubs =
-        getStudentClubList(userEmail, Constants.INTERESTED_CLUB_PROP, datastore);
+        ServletUtil.getPropertyList(student, Constants.INTERESTED_CLUB_PROP);
 
     ExploreInfo exploreInfo = new ExploreInfo(clubs, studentClubs, interestedClubs);
     String json = gson.toJson(exploreInfo);
     response.setContentType("application/json;");
     response.getWriter().println(json);
-  }
-
-  private static ImmutableList<String> getStudentClubList(
-      String userEmail, String property, DatastoreService datastore) {
-    Query query = new Query(userEmail);
-    PreparedQuery results = datastore.prepare(query);
-    Entity student = results.asSingleEntity();
-    if (student == null) {
-      return null;
-    }
-    return ServletUtil.getPropertyList(student, property);
   }
 
   private static boolean matchesLabels(Club club, ImmutableList<String> labels) {

--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -14,7 +14,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import com.google.gson.Gson;
-import com.google.sps.gmail.EmailFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;

--- a/capstone/src/main/java/com/google/sps/servlets/OAuth2CallbackServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/OAuth2CallbackServlet.java
@@ -20,6 +20,7 @@ public class OAuth2CallbackServlet extends AbstractAppEngineAuthorizationCodeCal
   @Override
   protected void onSuccess(HttpServletRequest req, HttpServletResponse resp, Credential credential)
       throws ServletException, IOException {
+
     resp.sendRedirect("/explore.html");
     resp.getWriter()
         .print(userEmail + " is logged in and has given access to their calendar and Gmail.");

--- a/capstone/src/main/java/com/google/sps/servlets/student/CheckStatusServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/CheckStatusServlet.java
@@ -1,0 +1,44 @@
+package com.google.sps.servlets;
+
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineAuthorizationCodeServlet;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet that redirects user to correct page after login */
+@WebServlet("/check-status")
+public class CheckStatusServlet extends AbstractAppEngineAuthorizationCodeServlet {
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    String userEmail = request.getUserPrincipal().getName();
+    Query query = new Query(userEmail);
+    PreparedQuery results = datastore.prepare(query);
+    ImmutableList<Entity> students = ImmutableList.copyOf(results.asIterable());
+    if (students.isEmpty()) {
+      response.sendRedirect("/explore?sort=default&labels=");
+    } else {
+      response.sendRedirect("/explore.html");
+    }
+  }
+
+  @Override
+  protected String getRedirectUri(HttpServletRequest req) throws ServletException, IOException {
+    return ServletUtil.getRedirectUri(req);
+  }
+
+  @Override
+  protected AuthorizationCodeFlow initializeFlow() throws IOException {
+    return ServletUtil.newFlow();
+  }
+}

--- a/capstone/src/main/java/com/google/sps/servlets/student/RedirectUserServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/student/RedirectUserServlet.java
@@ -15,8 +15,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /** Servlet that redirects user to correct page after login */
-@WebServlet("/check-status")
-public class CheckStatusServlet extends AbstractAppEngineAuthorizationCodeServlet {
+@WebServlet("/redirect-user")
+public class RedirectUserServlet extends AbstractAppEngineAuthorizationCodeServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -25,7 +25,10 @@ public class CheckStatusServlet extends AbstractAppEngineAuthorizationCodeServle
     Query query = new Query(userEmail);
     PreparedQuery results = datastore.prepare(query);
     ImmutableList<Entity> students = ImmutableList.copyOf(results.asIterable());
+
+    // Redirect user to link based on whether they have already visited ClubHub
     if (students.isEmpty()) {
+      // Redirect link for giving ClubHub access to Gmail and Calendar
       response.sendRedirect("/explore?sort=default&labels=");
     } else {
       response.sendRedirect("/explore.html");

--- a/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
+++ b/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
@@ -58,8 +58,7 @@ public final class ServletUtil {
     // If you want to run this locally, you will need to replace this with your dev server URI
     // - then add "/oauth2callback" to the end of it and add that to you API console under
     // Authorized URIs.
-    // return "https://clubhub-step-2020.googleplex.com/oauth2callback";
-    return "https://8080-4afd6625-e4a1-43f4-8d79-fc4c0cf1c87d.us-west1.cloudshell.dev/oauth2callback";
+    return "https://clubhub-step-2020.googleplex.com/oauth2callback";
   }
 
   public static GoogleAuthorizationCodeFlow newFlow() throws IOException {

--- a/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
+++ b/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
@@ -58,7 +58,8 @@ public final class ServletUtil {
     // If you want to run this locally, you will need to replace this with your dev server URI
     // - then add "/oauth2callback" to the end of it and add that to you API console under
     // Authorized URIs.
-    return "https://clubhub-step-2020.googleplex.com/oauth2callback";
+    // return "https://clubhub-step-2020.googleplex.com/oauth2callback";
+    return "https://8080-4afd6625-e4a1-43f4-8d79-fc4c0cf1c87d.us-west1.cloudshell.dev/oauth2callback";
   }
 
   public static GoogleAuthorizationCodeFlow newFlow() throws IOException {
@@ -73,6 +74,7 @@ public final class ServletUtil {
                 GmailScopes.GMAIL_SEND))
         .setDataStoreFactory(AppEngineDataStoreFactory.getDefaultInstance())
         .setAccessType(OFFLINE_ACCESS_TYPE)
+        .setApprovalPrompt("force")
         .build();
   }
 

--- a/capstone/src/main/webapp/club-registration.html
+++ b/capstone/src/main/webapp/club-registration.html
@@ -12,11 +12,11 @@
     <form id="club-form" action="/clubs?response_mode=form_post" class="full-screen-panel" method="POST">
       <div class="form-group">
         <label for="name">Name:</label>
-        <input type="text" name="name" id="club-name">
+        <input type="text" name="name" id="club-name" required>
       </div>
       <div class="form-group">
         <label for="description">Description:</label>
-        <input type="text" name="description" id="club-description">
+        <input type="text" name="description" id="club-description" required>
       </div>
       <div class="form-group">
         <label for="website">Website:</label>

--- a/capstone/src/main/webapp/index.html
+++ b/capstone/src/main/webapp/index.html
@@ -12,7 +12,7 @@
     <div class="split-front" id="intro-content">
       <p>Welcome to ClubHub, a platform to streamline communication between college campus organizations and college students</p>
       <p>Get started by logging in below!</p>
-      <form id="auth-form" action="/check-status" method="POST">
+      <form id="auth-form" action="/redirect-user" method="POST">
         <div id="login-button" class="g-signin2" data-onsuccess="onSignIn"></div>
       </form>
     </div>

--- a/capstone/src/main/webapp/index.html
+++ b/capstone/src/main/webapp/index.html
@@ -12,7 +12,9 @@
     <div class="split-front" id="intro-content">
       <p>Welcome to ClubHub, a platform to streamline communication between college campus organizations and college students</p>
       <p>Get started by logging in below!</p>
-      <div id="login-button" class="g-signin2" data-onsuccess="onSignIn"></div>
+      <form id="auth-form" action="/check-status" method="POST">
+        <div id="login-button" class="g-signin2" data-onsuccess="onSignIn"></div>
+      </form>
     </div>
   </body>
 </html>

--- a/capstone/src/main/webapp/profile-loader.js
+++ b/capstone/src/main/webapp/profile-loader.js
@@ -101,5 +101,5 @@ function fetchBlobstoreProfileUrl() {
 
 /** Direct to Explore page once logged in */
 function onSignIn() {
-  window.location.href = '/explore?sort=default&labels=';
+  document.getElementById('auth-form').submit();
 }

--- a/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
@@ -105,6 +105,7 @@ public final class ExploreServletTest {
     when(principal.getName()).thenReturn(KEVIN);
     when(request.getParameter(Constants.SORT_PROP)).thenReturn(Constants.DEFAULT_SORT_PROP);
     when(request.getParameter(Constants.LABELS_PROP)).thenReturn("");
+    when(request.getParameter(Constants.SERVICE_PROP)).thenReturn("do not test gmail service here");
 
     Entity club1 = new Entity(Constants.CLUB_ENTITY_PROP);
     club1.setProperty(Constants.PROPERTY_NAME, CLUB_1);

--- a/capstone/src/test/java/com/google/sps/servlets/student/RedirectUserServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/student/RedirectUserServletTest.java
@@ -1,0 +1,70 @@
+package com.google.sps.servlets;
+
+import static org.mockito.Mockito.when;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.io.IOException;
+import java.security.Principal;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnit4.class)
+public final class RedirectUserServletTest {
+  public static final String TEST_EMAIL = "test@example.com";
+
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  @Mock Principal principal;
+  private RedirectUserServlet redirectUserServlet = new RedirectUserServlet();
+  private LocalServiceTestHelper localHelper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+  private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    localHelper.setUp();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    localHelper.tearDown();
+  }
+
+  @Test
+  public void doPost_studentLogsInForFirstTime() throws ServletException, IOException {
+    localHelper.setEnvEmail(TEST_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
+    when(request.getUserPrincipal()).thenReturn(principal);
+    when(principal.getName()).thenReturn(TEST_EMAIL);
+    redirectUserServlet.doPost(request, response);
+
+    Mockito.verify(response).sendRedirect("/explore?sort=default&labels=");
+  }
+
+  @Test
+  public void doPost_studentHasLoggedInBefore() throws ServletException, IOException {
+    Entity testEntity = new Entity(TEST_EMAIL);
+    testEntity.setProperty(Constants.PROPERTY_EMAIL, TEST_EMAIL);
+    datastore.put(testEntity);
+
+    localHelper.setEnvEmail(TEST_EMAIL).setEnvAuthDomain("google.com").setEnvIsLoggedIn(true);
+    when(request.getUserPrincipal()).thenReturn(principal);
+    when(principal.getName()).thenReturn(TEST_EMAIL);
+    redirectUserServlet.doPost(request, response);
+
+    Mockito.verify(response).sendRedirect("/explore.html");
+  }
+}


### PR DESCRIPTION
In the past, the user would need to register a club or go to their profile page in order to give Gmail and Calendar access to ClubHub. However, since welcome emails should be sent once the user logs in, there have been a few errors appearing where the user would be redirected to a blank page with JSON. With these changes, the user now gives access as soon as they login for the first time and ClubHub redirects the user according to whether this is their first time logging in or not.