### PR TITLE
Add message to Explore page when there are no registered clubs

### DIFF
--- a/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/ExploreServlet.java
@@ -56,6 +56,11 @@ public class ExploreServlet extends AbstractAppEngineAuthorizationCodeServlet {
             .limit(Constants.LOAD_LIMIT)
             .collect(toImmutableList());
 
+    String noClubsMessage =
+        clubs.isEmpty()
+            ? "Welcome to ClubHub! There are no clubs to explore right now. :( Please register a new club!"
+            : "";
+
     // Get or create student entity and store club lists
     Entity student = StudentServlet.getStudent(request, userEmail, datastore);
     ImmutableList<String> studentClubs =
@@ -63,7 +68,7 @@ public class ExploreServlet extends AbstractAppEngineAuthorizationCodeServlet {
     ImmutableList<String> interestedClubs =
         ServletUtil.getPropertyList(student, Constants.INTERESTED_CLUB_PROP);
 
-    ExploreInfo exploreInfo = new ExploreInfo(clubs, studentClubs, interestedClubs);
+    ExploreInfo exploreInfo = new ExploreInfo(clubs, studentClubs, interestedClubs, noClubsMessage);
     String json = gson.toJson(exploreInfo);
     response.setContentType("application/json;");
     response.getWriter().println(json);
@@ -125,13 +130,16 @@ class ExploreInfo {
   private ImmutableList<Club> clubs;
   private ImmutableList<String> studentClubs;
   private ImmutableList<String> studentInterestedClubs;
+  private String noClubsMessage;
 
   public ExploreInfo(
       ImmutableList<Club> clubs,
       ImmutableList<String> studentClubs,
-      ImmutableList<String> studentInterestedClubs) {
+      ImmutableList<String> studentInterestedClubs,
+      String noClubsMessage) {
     this.clubs = clubs;
     this.studentClubs = studentClubs;
     this.studentInterestedClubs = studentInterestedClubs;
+    this.noClubsMessage = noClubsMessage;
   }
 }

--- a/capstone/src/main/java/com/google/sps/servlets/calendar/AddEventsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/calendar/AddEventsServlet.java
@@ -48,7 +48,7 @@ public class AddEventsServlet extends HttpServlet {
     } catch (Exception error) {
       System.out.println("Error: " + error);
     }
-    response.sendRedirect(request.getHeader("referer"));
+    response.sendRedirect(String.format("/about-us.html?name=%s&tab=calendar", clubName));
   }
 
   private String getCalendarId(String clubName) {

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -198,7 +198,10 @@ public class ClubServlet extends AbstractAppEngineAuthorizationCodeServlet {
             .setTimeZone(Constants.TIME_ZONE);
     String createdCalendarId = service.calendars().insert(calendar).execute().getId();
     // Enable reader permission for user
-    AclRule rule = new AclRule().setScope(new Scope().setType("default")).setRole("reader");
+    AclRule rule =
+        new AclRule()
+            .setScope(new Scope().setType(Constants.DEFAULT))
+            .setRole(USER_CALENDAR_PERMISSIONS);
     service.acl().insert(createdCalendarId, rule).execute();
     return createdCalendarId;
   }

--- a/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/clubs/ClubServlet.java
@@ -6,6 +6,8 @@ import com.google.api.client.extensions.appengine.auth.oauth2.AbstractAppEngineA
 import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.services.calendar.Calendar;
+import com.google.api.services.calendar.model.AclRule;
+import com.google.api.services.calendar.model.AclRule.Scope;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
@@ -188,13 +190,16 @@ public class ClubServlet extends AbstractAppEngineAuthorizationCodeServlet {
   }
 
   /** Return the Calendar ID after creating a calendar for the given club name. */
-  private String createCalendar(String clubName, Calendar service)
+  public String createCalendar(String clubName, Calendar service)
       throws IOException, GeneralSecurityException {
     com.google.api.services.calendar.model.Calendar calendar =
         new com.google.api.services.calendar.model.Calendar()
             .setSummary(clubName + " Calendar")
             .setTimeZone(Constants.TIME_ZONE);
     String createdCalendarId = service.calendars().insert(calendar).execute().getId();
+    // Enable reader permission for user
+    AclRule rule = new AclRule().setScope(new Scope().setType("default")).setRole("reader");
+    service.acl().insert(createdCalendarId, rule).execute();
     return createdCalendarId;
   }
 

--- a/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
+++ b/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
@@ -79,7 +79,8 @@ public final class ServletUtil {
     // If you want to run this locally, you will need to replace this with your dev server URI
     // - then add "/oauth2callback" to the end of it and add that to you API console under
     // Authorized URIs.
-    return "https://clubhub-step-2020.googleplex.com/oauth2callback";
+    // return "https://clubhub-step-2020.googleplex.com/oauth2callback";
+    return "https://8080-4afd6625-e4a1-43f4-8d79-fc4c0cf1c87d.us-west1.cloudshell.dev/oauth2callback";
   }
 
   public static GoogleAuthorizationCodeFlow newFlow() throws IOException {
@@ -94,7 +95,6 @@ public final class ServletUtil {
                 GmailScopes.GMAIL_SEND))
         .setDataStoreFactory(AppEngineDataStoreFactory.getDefaultInstance())
         .setAccessType(OFFLINE_ACCESS_TYPE)
-        .setApprovalPrompt("force")
         .build();
   }
 

--- a/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
+++ b/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
@@ -91,7 +91,8 @@ public final class ServletUtil {
                 CalendarScopes.CALENDAR,
                 GmailScopes.MAIL_GOOGLE_COM,
                 GmailScopes.GMAIL_INSERT,
-                GmailScopes.GMAIL_SEND))
+                GmailScopes.GMAIL_SEND,
+                CalendarScopes.CALENDAR_EVENTS))
         .setDataStoreFactory(AppEngineDataStoreFactory.getDefaultInstance())
         .setAccessType(OFFLINE_ACCESS_TYPE)
         .build();

--- a/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
+++ b/capstone/src/main/java/com/google/sps/servlets/utils/ServletUtil.java
@@ -79,8 +79,7 @@ public final class ServletUtil {
     // If you want to run this locally, you will need to replace this with your dev server URI
     // - then add "/oauth2callback" to the end of it and add that to you API console under
     // Authorized URIs.
-    // return "https://clubhub-step-2020.googleplex.com/oauth2callback";
-    return "https://8080-4afd6625-e4a1-43f4-8d79-fc4c0cf1c87d.us-west1.cloudshell.dev/oauth2callback";
+    return "https://clubhub-step-2020.googleplex.com/oauth2callback";
   }
 
   public static GoogleAuthorizationCodeFlow newFlow() throws IOException {

--- a/capstone/src/main/webapp/explore-loader.js
+++ b/capstone/src/main/webapp/explore-loader.js
@@ -33,6 +33,10 @@ async function getListings () {
   var query = '/explore?sort=' + sortType + '&labels=' + labels;
   const response = await fetch(query);
   const json = await response.json();
+  if (json.noClubsMessage != "") {
+    document.getElementById('no-clubs-message').innerText = json.noClubsMessage;
+    return;
+  }
   loadListings(json.clubs, json.studentClubs, json.studentInterestedClubs);
 }
 

--- a/capstone/src/main/webapp/explore-loader.js
+++ b/capstone/src/main/webapp/explore-loader.js
@@ -33,7 +33,7 @@ async function getListings () {
   var query = '/explore?sort=' + sortType + '&labels=' + labels;
   const response = await fetch(query);
   const json = await response.json();
-  if (json.noClubsMessage != "") {
+  if (json.noClubsMessage != '') {
     document.getElementById('no-clubs-message').innerText = json.noClubsMessage;
     return;
   }

--- a/capstone/src/main/webapp/explore-loader.js
+++ b/capstone/src/main/webapp/explore-loader.js
@@ -33,11 +33,10 @@ async function getListings () {
   var query = '/explore?sort=' + sortType + '&labels=' + labels;
   const response = await fetch(query);
   const json = await response.json();
-  if (json.noClubsMessage != '') {
-    document.getElementById('no-clubs-message').innerText = json.noClubsMessage;
-    return;
+  document.getElementById('no-clubs-message').innerText = json.noClubsMessage;
+  if (json.noClubsMessage == '') {
+    loadListings(json.clubs, json.studentClubs, json.studentInterestedClubs);
   }
-  loadListings(json.clubs, json.studentClubs, json.studentInterestedClubs);
 }
 
 async function loadListings (clubs, studentClubs, interestedClubs) {

--- a/capstone/src/main/webapp/explore.html
+++ b/capstone/src/main/webapp/explore.html
@@ -26,7 +26,9 @@
         </div>
         <ul id="labels"></ul>
       </div>
-      <div id="club-listings" class="full-screen-panel"></div>
+      <div id="club-listings" class="full-screen-panel">
+        <p id="no-clubs-message"></p>
+      </div>
       <template id="club-listing">
         <div class="club-logo-container">
           <img src="" id="club-logo" class="club-logo" alt="Club logo">

--- a/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/ExploreServletTest.java
@@ -50,6 +50,7 @@ import org.mockito.MockitoAnnotations;
  */
 @RunWith(JUnit4.class)
 public final class ExploreServletTest {
+  private static final String KEVIN = "kshao@google.com";
 
   private ExploreServlet servlet;
   @Mock private HttpServletRequest request;
@@ -75,9 +76,8 @@ public final class ExploreServletTest {
   }
 
   @Test
-  public void correctNumberAndObjectsReturned() throws IOException {
+  public void doGet_correctNumberAndObjectsReturned() throws IOException {
 
-    String KEVIN = "kshao@google.com";
     String MEGHA = "kakm@google.com";
     String MEGAN = "meganshi@google.com";
 
@@ -132,7 +132,8 @@ public final class ExploreServletTest {
     this.datastore.put(club1);
     this.datastore.put(club2);
 
-    JsonArray response = getServletResponse(servlet);
+    JsonObject fullResponse = getServletResponse(servlet);
+    JsonArray response = fullResponse.get("clubs").getAsJsonArray();
 
     int expectedSize = 2;
     Assert.assertEquals(expectedSize, response.size());
@@ -184,7 +185,24 @@ public final class ExploreServletTest {
     Assert.assertEquals(object1.get(Constants.TIME_PROP).getAsLong(), TIME_2);
   }
 
-  private JsonArray getServletResponse(ExploreServlet servlet) throws IOException {
+  @Test
+  public void doGet_noRegisteredClubs() throws IOException {
+    helper.setEnvEmail("kshao").setEnvAuthDomain("gmail.com").setEnvIsLoggedIn(true);
+    when(request.getUserPrincipal()).thenReturn(principal);
+    when(principal.getName()).thenReturn(KEVIN);
+    when(request.getParameter(Constants.SERVICE_PROP)).thenReturn("do not test gmail service here");
+
+    JsonObject fullResponse = getServletResponse(servlet);
+    String responseMessage = fullResponse.get("noClubsMessage").toString();
+    // Remove additional quotation marks from JSON
+    responseMessage = responseMessage.substring(1, responseMessage.length() - 1);
+    String expectedMessage =
+        "Welcome to ClubHub! There are no clubs to explore right now. :( Please register a new club!";
+
+    Assert.assertEquals(expectedMessage, responseMessage);
+  }
+
+  private JsonObject getServletResponse(ExploreServlet servlet) throws IOException {
     StringWriter stringWriter = new StringWriter();
     PrintWriter printWriter = new PrintWriter(stringWriter);
     when(response.getWriter()).thenReturn(printWriter);
@@ -194,7 +212,6 @@ public final class ExploreServletTest {
     String responseStr = stringWriter.toString().trim();
     JsonElement responseJsonElement = new JsonParser().parse(responseStr);
     JsonObject responseJsonObject = (JsonObject) responseJsonElement;
-
-    return responseJsonObject.get("clubs").getAsJsonArray();
+    return responseJsonObject;
   }
 }

--- a/capstone/src/test/java/com/google/sps/servlets/clubs/ClubServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/clubs/ClubServletTest.java
@@ -88,9 +88,7 @@ public class ClubServletTest {
     when(request.getUserPrincipal()).thenReturn(principal);
     when(principal.getName()).thenReturn("test-email@gmail.com");
     when(request.getParameter(Constants.EXCLUSIVE_PROP)).thenReturn(null);
-
     doPost_helper();
-    // clubServlet.doPostHelper(request, response, datastore, calendarService);
 
     Query query =
         new Query(Constants.CLUB_ENTITY_PROP)
@@ -118,9 +116,7 @@ public class ClubServletTest {
     when(request.getUserPrincipal()).thenReturn(principal);
     when(principal.getName()).thenReturn("test-email@gmail.com");
     when(request.getParameter(Constants.EXCLUSIVE_PROP)).thenReturn("on");
-
     doPost_helper();
-    // clubServlet.doPostHelper(request, response, datastore, calendarService);
 
     Query query =
         new Query(Constants.CLUB_ENTITY_PROP)
@@ -142,10 +138,7 @@ public class ClubServletTest {
     when(request.getUserPrincipal()).thenReturn(principal);
     when(principal.getName()).thenReturn("officer@example.com");
     doPost_helper();
-    // clubServlet.doPostHelper(request, response, datastore, calendarService);
-
     when(request.getParameter(Constants.DESCRIP_PROP)).thenReturn("club desc");
-    // clubServlet.doPostHelper(request, response, datastore, calendarService);
     doPost_helper();
 
     Mockito.verify(response).sendRedirect("/registration-msg.html?is-valid=false");


### PR DESCRIPTION
In the past, the Explore page would be empty if there were no registered clubs. This PR adds a message in this situation so the user is aware that there are currently no clubs and that they may still register a club. A test has also been added to ensure the message is displayed when there are no registered clubs. 